### PR TITLE
File adapter issue76 problem with merging data rather than replacing

### DIFF
--- a/File_Adapter/CRUD/Create.cs
+++ b/File_Adapter/CRUD/Create.cs
@@ -40,9 +40,9 @@ namespace BH.Adapter.FileAdapter
         protected override bool Create<T>(IEnumerable<T> objects, bool replaceAll = false)
         {
             if (m_Readable)
-                return CreateJson((IEnumerable<IBHoMObject>)objects);
+                return CreateJson((IEnumerable<IBHoMObject>)objects, replaceAll);
             else
-                return CreateBson((IEnumerable<IBHoMObject>)objects);
+                return CreateBson((IEnumerable<IBHoMObject>)objects, replaceAll);
         }
 
 

--- a/File_Adapter/CRUD/Push.cs
+++ b/File_Adapter/CRUD/Push.cs
@@ -39,7 +39,19 @@ namespace BH.Adapter.FileAdapter
         {
             CreateFileAndFolder();
 
-            return base.Push(objects, tag, config);
+            bool success = true;
+
+            List<IObject> objectsToPush = Config.CloneBeforePush ? objects.Select(x => x is BHoMObject ? ((BHoMObject)x).GetShallowClone() : x).ToList() : objects.ToList(); //ToList() necessary for the return collection to function properly for cloned objects
+
+
+            IEnumerable<IBHoMObject> bhomObjects = objectsToPush.Where(x => x is IBHoMObject).Cast<IBHoMObject>();
+
+            if (objects.Count() != objects.Count())
+                Engine.Reflection.Compute.RecordError("The file adapter can currently only be used with BHoMObjects. Please check your input data");
+
+            this.Replace<IBHoMObject>(bhomObjects, tag);
+
+            return success ? objectsToPush : new List<IObject>();
         }
     }
 }

--- a/File_Adapter/File_Adapter.csproj
+++ b/File_Adapter/File_Adapter.csproj
@@ -37,6 +37,10 @@
     <Reference Include="MongoDB.Bson, Version=2.7.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MongoDB.Bson.2.7.2\lib\net45\MongoDB.Bson.dll</HintPath>
     </Reference>
+    <Reference Include="Reflection_Engine, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM_Engine\Build\Reflection_Engine.dll</HintPath>
+    </Reference>
     <Reference Include="Serialiser_Engine">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM_Engine\Build\Serialiser_Engine.dll</HintPath>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #76 

<!-- Add short description of what has been fixed -->

Fixes pushing to the file adapter making use of tags, enabling replacing separate sections of a written file, as opposed to always appending.

Behaviour after this change:

- Pushing with no tag provided will lead to previous behaviour which means just adding to the file, with no replacing happening.
- Pushing with tags should lead to replacement of any object that have been pushed with this tag, independent of which type of object they are. For example, if you push a list of Bars with tag "myObjects" and then push some nodes with the tag "myObjects", all the Bars in the file with this tag will be replace by the new nodes.

### Test files
<!-- Link to test files to validate the proposed changes -->

[FileAdapterWithTags.zip](https://github.com/BHoM/BHoM_Adapter/files/2795445/FileAdapterWithTags.zip)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Adding specific push method to the File_Adapter and modifications to the Create method for the File_Adapter, enabling replacing items in a file using tags.

### Additional comments
<!-- As required -->