### PR TITLE
Adding reference to Analytical_oM

### DIFF
--- a/BHoM_Adapter/BHoM_Adapter.csproj
+++ b/BHoM_Adapter/BHoM_Adapter.csproj
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Analytical_oM">
+      <HintPath>..\..\BHoM\Build\Analytical_oM.dll</HintPath>
+    </Reference>
     <Reference Include="BHoM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>

--- a/BHoM_Adapter/HelperMethods/MapSpecialProperties.cs
+++ b/BHoM_Adapter/HelperMethods/MapSpecialProperties.cs
@@ -65,8 +65,8 @@ namespace BH.Adapter
         private static void _MapSpecialProperties(Node target, Node source)
         {
             //Check if the source is constraint och taget not, if so add source constraint to target
-            if (source.Constraint != null && target.Constraint == null)
-                target.Constraint = source.Constraint;
+            if (source.Support != null && target.Support == null)
+                target.Support = source.Support;
 
             //If target does not have name, take sources name //TODO: could that be done for all BHoM objects?
             if (string.IsNullOrWhiteSpace(target.Name))


### PR DESCRIPTION
### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/481

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #81 

<!-- Add short description of what has been fixed -->
Adding reference to Analytical_oM

Done in parallel to Structure_oM sprint, but this could be merged before as only change made is updating references

**EDIT** now depends on BHoM change for the Node class

### Additional comments
<!-- As required -->

Could be discussed if these dependencies should exist at all, but as current adapter has a dependecy on Structure_oM due to "MapSpecialProperties" method, the dependencies needs to be updated.

Removing these dependencies can be done as a separate sprint if wanted.