### PR TITLE
BHoM_Adapter - Adding check as to whether a read in necessary in Replace method

### DIFF
--- a/BHoM_Adapter/CRUD/Replace.cs
+++ b/BHoM_Adapter/CRUD/Replace.cs
@@ -46,7 +46,12 @@ namespace BH.Adapter
                 newObjects.ForEach(x => x.Tags.Add(tag));
 
             //Read all the existing objects of that type
-            IEnumerable<T> existing = Read(typeof(T)).Where(x => x != null && x is T).Cast<T>();
+            IEnumerable<T> existing;
+
+            if (tag != "" || Comparer<T>() != EqualityComparer<T>.Default)
+                existing = Read(typeof(T)).Where(x => x != null && x is T).Cast<T>();
+            else
+                existing = new List<T>();
 
             // Merge and push the dependencies
             if (Config.SeparateProperties)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #102 

<!-- Add short description of what has been fixed -->

If no tag is provided and if no comparer is provided, reading in existing data is unnecessary, as this mean non of the comparison methods will be able to do anything.

Adding check for this in Replace method

### Test files
<!-- Link to test files to validate the proposed changes -->

Test that any push methods are working as before.

I have been runnig on this code for quite some time and have not experienced any problems. SHould give a speedup pushing elements without comparers to models already containing data. For example pushing panels to a Robot model already containing a large set of panels.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->