### PR TITLE
Remove the unused `replaceAll` parameter from the Create() method signature

### DIFF
--- a/BHoM_Adapter/BHoMAdapter.cs
+++ b/BHoM_Adapter/BHoMAdapter.cs
@@ -203,7 +203,7 @@ namespace BH.Adapter
 
         // Level 1 - Always required
 
-        protected abstract bool Create<T>(IEnumerable<T> objects, bool replaceAll = false) where T : IObject;
+        protected abstract bool Create<T>(IEnumerable<T> objects) where T : IObject;
 
         protected abstract IEnumerable<IBHoMObject> Read(Type type, IList ids);
 

--- a/BHoM_Adapter/CRUD/Replace.cs
+++ b/BHoM_Adapter/CRUD/Replace.cs
@@ -66,26 +66,18 @@ namespace BH.Adapter
 
             // Replace objects that overlap and define the objects that still have to be pushed
             IEnumerable<T> objectsToCreate = newObjects;
-            bool overwriteObjects = false;
 
             if (Config.ProcessInMemory)
-            {
                 objectsToCreate = ReplaceInMemory(newObjects, existing, tag);
-                overwriteObjects = true;
-            }
             else
-            {
                 objectsToCreate = ReplaceThroughAPI(newObjects, existing, tag);
-            }
 
             // Assign Id if needed
             if (Config.UseAdapterId)
-            {
                 AssignId(objectsToCreate);
-            }
 
             // Create objects
-            if (!Create(objectsToCreate, overwriteObjects))
+            if (!Create(objectsToCreate))
                 return false;
             else if (Config.UseAdapterId)
             {

--- a/BHoM_Adapter/CRUD/UpdateProperty.cs
+++ b/BHoM_Adapter/CRUD/UpdateProperty.cs
@@ -40,7 +40,7 @@ namespace BH.Adapter
             if (Config.ProcessInMemory)
             {
                 IEnumerable<IBHoMObject> objects = UpdateInMemory(filter, property, newValue);
-                Create(objects, true);
+                Create(objects);
                 return objects.Count();
             }
             else

--- a/File_Adapter/CRUD/Create.cs
+++ b/File_Adapter/CRUD/Create.cs
@@ -37,12 +37,15 @@ namespace BH.Adapter.FileAdapter
         /**** Public Methods                            ****/
         /***************************************************/
 
-        protected override bool Create<T>(IEnumerable<T> objects, bool replaceAll = false)
+        protected override bool Create<T>(IEnumerable<T> objects)
         {
+
+            bool clearFile = Config.ProcessInMemory;
+
             if (m_isJSON)
-                return CreateJson((IEnumerable<IBHoMObject>)objects, replaceAll);
+                return CreateJson((IEnumerable<IBHoMObject>)objects, clearFile);
             else
-                return CreateBson((IEnumerable<IBHoMObject>)objects, replaceAll);
+                return CreateBson((IEnumerable<IBHoMObject>)objects, clearFile);
         }
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

## IMPORTANT NOTE
This change will affect **ALL TOOLKITS**.

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #114 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Try pushing and pulling using the File Adapter:
https://burohappold.sharepoint.com/:f:/s/BHoM/Er7Im8cjGmFKgFX5J61qciMB_7g9xTRfl76uqYWLNU60dw?e=fX5Nvk

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Removed the parameter `replaceAll` from the `Create()` method signature
- Changed the File_Adapter to comply with that
