### PR TITLE
Fixing base Adapter correctly calling Read methods on concrete adapters

### DIFF
--- a/BHoM_Adapter/AdapterActions/Pull.cs
+++ b/BHoM_Adapter/AdapterActions/Pull.cs
@@ -52,11 +52,13 @@ namespace BH.Adapter
                     return ReadResults(filterReq);
             // --------------------------------------------------------------------------------- //
 
+            //Casting the adapter to its instance type (this as dynamic) to make sure all ReadResults methods are captured
             if (request is IResultRequest)
-                return ReadResults(request as dynamic);
+                return (this as dynamic).ReadResults(request as dynamic);
 
+            //Casting the adapter to its instance type (this as dynamic) to make sure all Read methods are captured
             if (request is IRequest)
-                return Read(request as dynamic);
+                return (this as dynamic).Read(request as dynamic);
 
             return new List<object>();
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #165 

<!-- Add short description of what has been fixed -->

Casting adapter as dynamic before Read and ReadResults dispatch calls

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Casting adapter to its concrete type before dispatching requests in Pull

### Additional comments
<!-- As required -->