### PR TITLE
Added PushConfig and PullConfig (as childs of ActionConfig)

### DIFF
--- a/Adapter_Engine/Query/GetComparerForType.cs
+++ b/Adapter_Engine/Query/GetComparerForType.cs
@@ -43,19 +43,19 @@ namespace BH.Engine.Adapter
         // These are support methods required by other methods in the Push process.
 
         [Description("Returns the comparer to be used with a certain object type.")]
-        public static IEqualityComparer<T> GetComparerForType<T>(this IBHoMAdapter bHoMAdapter, ActionConfig actionConfig = null) where T : IBHoMObject
+        public static IEqualityComparer<T> GetComparerForType<T>(this IBHoMAdapter bHoMAdapter, PushConfig pushConfig = null) where T : IBHoMObject
         {
             Type type = typeof(T);
 
-            if (bHoMAdapter.AdapterComparers.ContainsKey(type))
-                return bHoMAdapter.AdapterComparers[type] as IEqualityComparer<T>;
-
-            if (actionConfig != null && actionConfig.AllowHashForComparing)
+            if (pushConfig != null && pushConfig.AllowHashForComparing)
             {
                 var propertiesToIgnore = new List<string>() { "BHoM_Guid", "CustomData" };
 
                 return new HashFragmComparer<T>(propertiesToIgnore);
             }
+
+            if (bHoMAdapter.AdapterComparers.ContainsKey(type))
+                return bHoMAdapter.AdapterComparers[type] as IEqualityComparer<T>;
 
             return EqualityComparer<T>.Default;
         }

--- a/Adapter_oM/Adapter_oM.csproj
+++ b/Adapter_oM/Adapter_oM.csproj
@@ -81,6 +81,8 @@
     <Compile Include="ObjectWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings-Config\ActionConfig.cs" />
+    <Compile Include="Settings-Config\PullConfig.cs" />
+    <Compile Include="Settings-Config\PushConfig.cs" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Adapter_oM/Settings-Config/PullConfig.cs
+++ b/Adapter_oM/Settings-Config/PullConfig.cs
@@ -26,13 +26,14 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapter
 {
-    [Description("Base Adapter configurations for any Adapter Action (Push, Pull, etc)." +
-        "\nConsider that your tookit might have a more specific implementation available. Try to look for [your toolkit name]ActionConfig.")]
-    public class ActionConfig : IObject
+    [Description("Configurations for the Pull action."+
+        "\nConsider that your tookit might have a more specific implementation available. Try to look for [your toolkit name]PushConfig.")]
+    public class PullConfig : ActionConfig
     {
-        // You can make your own ActionConfig for your Toolkit, e.g. SpeckleActionConfig.
+        // You can make your own PushConfig for your Toolkit, e.g. SpecklePushConfig.
         // To do so, inherit this class. You will so be able to pass it to any method (like the Push) that accepts ActionConfig.
-        // Then to use it, you will need to cast the actionConfig parameter to your own ActionConfig type within each method.
+        // Then to use it, you will need to cast it to your implementation.
     }
 }
+
 

--- a/Adapter_oM/Settings-Config/PushConfig.cs
+++ b/Adapter_oM/Settings-Config/PushConfig.cs
@@ -26,13 +26,17 @@ using System.ComponentModel;
 
 namespace BH.oM.Adapter
 {
-    [Description("Base Adapter configurations for any Adapter Action (Push, Pull, etc)." +
-        "\nConsider that your tookit might have a more specific implementation available. Try to look for [your toolkit name]ActionConfig.")]
-    public class ActionConfig : IObject
+    [Description("Base Adapter configurations for the Push action." +
+        "\nConsider that your tookit might have a more specific implementation available. Try to look for [your toolkit name]PushConfig.")]
+    public class PushConfig : ActionConfig
     {
-        // You can make your own ActionConfig for your Toolkit, e.g. SpeckleActionConfig.
+        // You can make your own PushConfig for your Toolkit, e.g. SpecklePushConfig.
         // To do so, inherit this class. You will so be able to pass it to any method (like the Push) that accepts ActionConfig.
-        // Then to use it, you will need to cast the actionConfig parameter to your own ActionConfig type within each method.
+        // Then to use it, you will need to cast it to your implementation.
+
+        public bool WrapNonBHoMObjects { get; set; } = false;
+        public bool AllowHashForComparing { get; set; } = false;
     }
 }
+
 

--- a/BHoM_Adapter/AdapterActions/Push.cs
+++ b/BHoM_Adapter/AdapterActions/Push.cs
@@ -56,7 +56,7 @@ namespace BH.Adapter
                 pushType = m_AdapterSettings.DefaultPushType;
 
             // Process the objects (verify they are valid; DeepClone them, wrap them, etc).
-            IEnumerable<IBHoMObject> objectsToPush = ProcessObjectsForPush(objects, actionConfig); // Note: default Push only supports IBHoMObjects.
+            IEnumerable<IBHoMObject> objectsToPush = ProcessObjectsForPush(objects, actionConfig as PushConfig); // Note: default Push only supports IBHoMObjects.
 
             if (objectsToPush.Count() == 0)
             {

--- a/BHoM_Adapter/AdapterActions/_PushMethods/ProcessObjectsForPush.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/ProcessObjectsForPush.cs
@@ -41,7 +41,7 @@ namespace BH.Adapter
         // These are support methods required by other methods in the Push process.
 
         [Description("Prepares the objects for the Push.")]
-        protected virtual IEnumerable<IBHoMObject> ProcessObjectsForPush(IEnumerable<object> objects, ActionConfig actionConfig) 
+        protected virtual IEnumerable<IBHoMObject> ProcessObjectsForPush(IEnumerable<object> objects, PushConfig pushConfig = null) 
         {
             // -------------------------------- // 
             //            READ CONFIG           // 
@@ -49,8 +49,8 @@ namespace BH.Adapter
 
             // If ActionConfig has a value for `WrapNonBHoMObjects`, it has precedence over the default value in AdapterSettings.
             bool wrapNonBHoMObjects = m_AdapterSettings.WrapNonBHoMObjects;
-            if (actionConfig != null)
-                wrapNonBHoMObjects = actionConfig.WrapNonBHoMObjects;
+            if (pushConfig != null)
+                wrapNonBHoMObjects = pushConfig.WrapNonBHoMObjects;
 
 
             // -------------------------------- // 

--- a/File_Adapter/AdapterActions/Push.cs
+++ b/File_Adapter/AdapterActions/Push.cs
@@ -38,7 +38,7 @@ namespace BH.Adapter.FileAdapter
             // --------------- SET-UP ------------------
 
             // Process the objects (verify they are valid; DeepClone them, wrap them, etc).
-            IEnumerable<IBHoMObject> objectsToPush = ProcessObjectsForPush(objects, actionConfig); // Note: default Push only supports IBHoMObjects.
+            IEnumerable<IBHoMObject> objectsToPush = ProcessObjectsForPush(objects, actionConfig as PushConfig); // Note: default Push only supports IBHoMObjects.
 
             if (objectsToPush.Count() == 0)
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #191 

This allows to get more clarity in the Toolkits: you can implement more specific types of ActionConfig.

Also, the base ActionConfig properties which I included (WrapNonBHoMObjects, etc) only apply to the PushActionConfig.

### Test files
No test needed.
