### PR TITLE
Add CreateNonExisting push type and methods

### DIFF
--- a/Adapter_oM/enums/PushType.cs
+++ b/Adapter_oM/enums/PushType.cs
@@ -33,7 +33,8 @@ namespace BH.oM.Adapter
         "CreateOnly - Uses only the Create CRUD method to export the objects. This may create duplicates if the object already exists.\n" +
         "UpdateOnly - Uses only the Update CRUD method to update the objects in the external software. All other objects in the model are left untouched.\n" +
         "DeleteThenCreate - For all objects being Pushed, identifies their type, calls Delete to remove all of those types, then it Creates them.\n" +
-        "AdapterDefault - Picks the value hard-coded in the Adapter.")]
+        "AdapterDefault - Picks the value hard-coded in the Adapter. \n" +
+        "CreateNonExisting - Same as FullCRUD, but does not update existing objects.")]
     public enum PushType //add error message if not picked up --> compliance check for this?
     {
         [Description("Calls all CRUD methods as appropriate.")]
@@ -45,7 +46,8 @@ namespace BH.oM.Adapter
         [Description("For all objects being Pushed, identifies their type, calls Delete to remove all of those types, then it Creates them.")]
         DeleteThenCreate,
         [Description("If this is chosen, then the m_AdapterSettings.DefaultPushType is picked.")]
-        AdapterDefault
+        AdapterDefault,
+        CreateNonExisting
     }
 }
 

--- a/Adapter_oM/enums/PushType.cs
+++ b/Adapter_oM/enums/PushType.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Adapter
 {
-    [Description("Controls which of the push methods that should be used by the Adapter.")]
+    [Description("Controls which type of export should be done by the Adapter `Push` action.")]
     public enum PushType //add error message if not picked up --> compliance check for this?
     {
         [Description("Calls all CRUD methods as appropriate.")]
@@ -38,13 +38,12 @@ namespace BH.oM.Adapter
         CreateOnly,
         [Description("Same as FullCRUD, but does not update pre-existing objects.")]
         CreateNonExisting,
-        [Description("Uses only the Update CRUD method to update the objects in the external software.")]
+        [Description(" Uses only the Update CRUD method to update the objects in the external software. All other objects in the model are left untouched.")]
         UpdateOnly,
         [Description("For all objects being Pushed, identifies their type, calls Delete to remove all of those types, then it Creates them.")]
         DeleteThenCreate,
-        [Description("If this is chosen, then the m_AdapterSettings.DefaultPushType is picked.")]
+        [Description("AdapterDefault - Picks the value hard-coded in the specific Adapter.")] // If this is chosen, then the m_AdapterSettings.DefaultPushType is picked
         AdapterDefault
 
     }
 }
-

--- a/Adapter_oM/enums/PushType.cs
+++ b/Adapter_oM/enums/PushType.cs
@@ -29,19 +29,14 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Adapter
 {
-    [Description("FullCRUD - Calls all CRUD methods as appropriate.\n" +
-        "CreateOnly - Uses only the Create CRUD method to export the objects. This may create duplicates if the object already exists.\n" +
-        "UpdateOnly - Uses only the Update CRUD method to update the objects in the external software. All other objects in the model are left untouched.\n" +
-        "DeleteThenCreate - For all objects being Pushed, identifies their type, calls Delete to remove all of those types, then it Creates them.\n" +
-        "AdapterDefault - Picks the value hard-coded in the Adapter. \n" +
-        "CreateNonExisting - Same as FullCRUD, but does not update existing objects.")]
+    [Description("Controls which of the push methods that should be used by the Adapter.")]
     public enum PushType //add error message if not picked up --> compliance check for this?
     {
         [Description("Calls all CRUD methods as appropriate.")]
         FullCRUD,
         [Description("Uses only the Create CRUD method to export the objects. This may create duplicates if the object already exists.")]
         CreateOnly,
-        [Description("CreateNonExisting - Same as FullCRUD, but does not update existing objects.")]
+        [Description("Same as FullCRUD, but does not update pre-existing objects.")]
         CreateNonExisting,
         [Description("Uses only the Update CRUD method to update the objects in the external software.")]
         UpdateOnly,

--- a/Adapter_oM/enums/PushType.cs
+++ b/Adapter_oM/enums/PushType.cs
@@ -38,7 +38,7 @@ namespace BH.oM.Adapter
         CreateOnly,
         [Description("Same as FullCRUD, but does not update pre-existing objects.")]
         CreateNonExisting,
-        [Description(" Uses only the Update CRUD method to update the objects in the external software. All other objects in the model are left untouched.")]
+        [Description("Uses only the Update CRUD method to update the objects in the external software. All other objects in the model are left untouched.")]
         UpdateOnly,
         [Description("For all objects being Pushed, identifies their type, calls Delete to remove all of those types, then it Creates them.")]
         DeleteThenCreate,

--- a/Adapter_oM/enums/PushType.cs
+++ b/Adapter_oM/enums/PushType.cs
@@ -41,13 +41,15 @@ namespace BH.oM.Adapter
         FullCRUD,
         [Description("Uses only the Create CRUD method to export the objects. This may create duplicates if the object already exists.")]
         CreateOnly,
+        [Description("CreateNonExisting - Same as FullCRUD, but does not update existing objects.")]
+        CreateNonExisting,
         [Description("Uses only the Update CRUD method to update the objects in the external software.")]
         UpdateOnly,
         [Description("For all objects being Pushed, identifies their type, calls Delete to remove all of those types, then it Creates them.")]
         DeleteThenCreate,
         [Description("If this is chosen, then the m_AdapterSettings.DefaultPushType is picked.")]
-        AdapterDefault,
-        CreateNonExisting
+        AdapterDefault
+
     }
 }
 

--- a/BHoM_Adapter/AdapterActions/Push.cs
+++ b/BHoM_Adapter/AdapterActions/Push.cs
@@ -77,7 +77,7 @@ namespace BH.Adapter
                 MethodInfo enumCastMethod_specificType = typeof(Enumerable).GetMethod("Cast").MakeGenericMethod(new[] { typeGroup.Key });
                 var objList_specificType = enumCastMethod_specificType.Invoke(typeGroup, new object[] { typeGroup });
 
-                if (pushType == PushType.FullCRUD)
+                if (pushType == PushType.FullCRUD || pushType == PushType.CreateNonExisting)
                     success &= FullCRUD(objList_specificType as dynamic, pushType, tag, actionConfig);
                 else if (pushType == PushType.CreateOnly)
                 {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #204 

<!-- Add short description of what has been fixed -->

As stated in Issue, adding additional PushType, working exactly as FUllCRUD, except it does not call Update for the intersection of the venn diagram. Instead only UpdateTags is being called, for obejcts that do contain tags.

General principle: Create stuff not already in the model, leave the rest.
Which is different from the default CRUD: Create stuff not existing, update the rest.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EkXvc8ZBXOZNr7HhmSEuzW8BS6e5UN6hCkJMXHCfO2E3Xg?e=lniam2

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->

@JosefTaylor , I think this should resolve https://github.com/BHoM/ETABS_Toolkit/issues/102