### PR TITLE
Always assign new ids for objects being created

### DIFF
--- a/BHoM_Adapter/AdapterActions/_PushMethods/ExternalId/AssignId.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/ExternalId/AssignId.cs
@@ -39,7 +39,7 @@ namespace BH.Adapter
             bool refresh = true;
             foreach (T item in objects)
             {
-                if (AdapterIdName != null && !item.CustomData.ContainsKey(AdapterIdName))
+                if (AdapterIdName != null)
                 {
                     item.CustomData[AdapterIdName] = NextFreeId(typeof(T), refresh);
                     refresh = false;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #208 

<!-- Add short description of what has been fixed -->
Removing check if object already has an AdapterId for objects to be created.
See issue for more details, but this means new objects, set to be created, should always get a new id assigned, independent if they had one before or not.

### Test files
<!-- Link to test files to validate the proposed changes -->
@kThorsager do you have a link to the scripts giving you problems?

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Removing check if AdapterNameId already exists in custom data before assigning fresh id to objects being created.

### Additional comments
<!-- As required -->