### PR TITLE
Adapter_Engine: extraction of CRUD methods compatible with specific objects types

### DIFF
--- a/Adapter_Engine/Adapter_Engine.csproj
+++ b/Adapter_Engine/Adapter_Engine.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Modify\CopyBHoMObjectProperties.cs" />
     <Compile Include="Modify\WrapNonBHoMObjects.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Query\AdapterMethods.cs" />
     <Compile Include="Query\GetComparerForType.cs" />
     <Compile Include="Query\GetDependencyTypes.cs" />
     <Compile Include="Query\GetFullFileName.cs" />

--- a/Adapter_Engine/Query/AdapterMethods.cs
+++ b/Adapter_Engine/Query/AdapterMethods.cs
@@ -1,0 +1,177 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+
+
+namespace BH.Engine.Adapter
+{
+  static partial class Query
+  {
+    /***************************************************/
+    /**** Public Methods                            ****/
+    /***************************************************/
+
+    [Description("Returns a list of MethodInfo with all methods contained in classes whose name ends with `Adapter`.")]
+    public static List<MethodInfo> AdapterMethods()
+    {
+      // If the list exists already, return it
+      if (m_AdapterMethodsList != null && m_AdapterMethodsList.Count > 0)
+        return m_AdapterMethodsList;
+      else
+      {
+        List<MethodInfo> allMethods = BH.Engine.Reflection.Query.AllMethodList().OfType<MethodInfo>().ToList();
+        m_AdapterMethodsList = allMethods.Where(x => x.DeclaringType.Name.EndsWith("Adapter")).ToList();
+        // (if we moved the IBHoMAdapter interface from the BHoM_Adapter down in the base BH.oM, we could test for inheritance instead of "EndsWith")
+      }
+      return m_AdapterMethodsList;
+    }
+
+    /***************************************************/
+
+    [Description("Returns a collection with all CRUD-named methods found in all the Adapters loaded at runtime, grouped per CRUD type." +
+      "CRUD-named means whose name contains any of the CRUD keywords: `Create`, `Read`, `Update`, `Delete`.")]
+    [Output("Dictionary with string key, one of: `Create`, `Read`, `Update`, `Delete`; value is the List of CRUD methods.")]
+    public static Dictionary<string, List<MethodInfo>> AdaptersCRUDNamedMethods()
+    {
+      List<MethodInfo> adapterMethods = AdapterMethods();
+
+      // Select methods whose name includes any of keywords and group them based on that
+      List<string> CreateKeywords = new List<string>() { "Create", "CreateCollection", "CreateObject" };
+      List<string> ReadKeywords = new List<string>() { "Read" };
+      List<string> UpdateKeywords = new List<string>() { "Update" };
+      List<string> DeleteKeywords = new List<string>() { "Delete" };
+
+      Dictionary<string, List<MethodInfo>> GroupedCRUDmethods = new Dictionary<string, List<MethodInfo>>();
+
+      GroupedCRUDmethods.Add("Create", adapterMethods.Where(x => CreateKeywords.Any(s => x.Name.Contains(s))).ToList());
+      GroupedCRUDmethods.Add("Read", adapterMethods.Where(x => ReadKeywords.Any(s => x.Name.Contains(s))).ToList());
+      GroupedCRUDmethods.Add("Update", adapterMethods.Where(x => UpdateKeywords.Any(s => x.Name.Contains(s))).ToList());
+      GroupedCRUDmethods.Add("Delete", adapterMethods.Where(x => DeleteKeywords.Any(s => x.Name.Contains(s))).ToList());
+
+      return GroupedCRUDmethods;
+    }
+
+    /***************************************************/
+
+    [Description("Returns a collection of all Types that are supported by some CRUD action, grouped per object type.")]
+    [Output("Dictionary with string key, one of: `Create`, `Read`, `Update`, `Delete`;\n" +
+        "value is a Dictionary with key: BHoM Type of with some CRUD method that supports it; value: list of CRUD methods compatible with that Type.")]
+    public static Dictionary<string, Dictionary<Type, List<MethodInfo>>> AllCRUDcompatibleTypes()
+    {
+      Dictionary<string, Dictionary<Type, List<MethodInfo>>> result = new Dictionary<string, Dictionary<Type, List<MethodInfo>>>();
+
+      Dictionary<string, List<MethodInfo>> adapterCRUDMethods = AdaptersCRUDNamedMethods();
+
+      result["Create"] = Create_CompatibleTypes(adapterCRUDMethods["Create"]);
+      result["Read"] = Read_CompatibleTypes(adapterCRUDMethods["Read"]);
+      // Update and Delete support to be added in the future.
+
+      return result;
+    }
+
+    /***************************************************/
+    /**** Private Methods                           ****/
+    /***************************************************/
+
+    private static Dictionary<Type, List<MethodInfo>> Create_CompatibleTypes(List<MethodInfo> createMethods)
+    {
+      Dictionary<Type, List<MethodInfo>> result = new Dictionary<Type, List<MethodInfo>>();
+
+      for (int i = 0; i < createMethods.Count; i++)
+      {
+        // For Create methods, the compatibility is given by the type of the FIRST parameter of the method.
+        ParameterInfo firstPar = createMethods[i].GetParameters().FirstOrDefault();
+
+        if (firstPar != null && firstPar.ParameterType.IsOfAllowedTypes())
+        {
+          if (!result.ContainsKey(firstPar.ParameterType))
+            result[firstPar.ParameterType] = new List<MethodInfo>() { createMethods[i] };
+          else
+            result[firstPar.ParameterType].Add(createMethods[i]);
+        }
+      }
+      return result;
+    }
+
+    /***************************************************/
+
+    private static Dictionary<Type, List<MethodInfo>> Read_CompatibleTypes(List<MethodInfo> readMethods)
+    {
+      Dictionary<Type, List<MethodInfo>> result = new Dictionary<Type, List<MethodInfo>>();
+
+      for (int i = 0; i < readMethods.Count; i++)
+      {
+        // For Read methods, the compatibility is given by the return type of the method.
+        Type returnType = readMethods[i].ReturnType;
+        if (returnType != null && returnType.IsOfAllowedTypes())
+        {
+          if (!result.ContainsKey(returnType))
+            result[returnType] = new List<MethodInfo>() { readMethods[i] };
+          else
+            result[returnType].Add(readMethods[i]);
+        }
+      }
+      return result;
+    }
+
+    /***************************************************/
+
+    // To collect CRUD methods that support certain object types, we need to exclude all types that are not one of allowed types.
+    private static bool IsOfAllowedTypes(this Type type)
+    {
+      bool isOfAllowedTypes = false;
+
+      // If the type is a collection with a generic argument, extract the contained type.
+      // This way we can collect types like IEnumerable<Bar> --> Bar.
+      Type genericType = type.GetGenericArguments().FirstOrDefault();
+      if (genericType != null)
+        type = genericType;
+
+      if (type.IsSubclassOf(typeof(BHoMObject)))
+        isOfAllowedTypes = true;
+
+      if (type.IsSubclassOf(typeof(IObject)) && type != typeof(BHoMObject))
+        isOfAllowedTypes = true;
+
+      // Some types must be excluded by default.
+      // E.g. BHoM Fragments cannot be a type that can be `Create`d.
+      if (typeof(IFragment).IsAssignableFrom(type))
+        isOfAllowedTypes = false;
+
+      return isOfAllowedTypes;
+    }
+
+    /***************************************************/
+    /**** Private Fields                            ****/
+    /***************************************************/
+
+    private static List<MethodInfo> m_AdapterMethodsList = new List<MethodInfo>();
+  }
+}
+

--- a/Adapter_Engine/Query/AdapterMethods.cs
+++ b/Adapter_Engine/Query/AdapterMethods.cs
@@ -82,7 +82,7 @@ namespace BH.Engine.Adapter
     [Description("Returns a collection of all Types that are supported by some CRUD action, grouped per object type.")]
     [Output("Dictionary with string key, one of: `Create`, `Read`, `Update`, `Delete`;\n" +
         "value is a Dictionary with key: BHoM Type of with some CRUD method that supports it; value: list of CRUD methods compatible with that Type.")]
-    public static Dictionary<string, Dictionary<Type, List<MethodInfo>>> AllCRUDcompatibleTypes()
+    public static Dictionary<string, Dictionary<Type, List<MethodInfo>>> CRUDcompatibleTypes()
     {
       Dictionary<string, Dictionary<Type, List<MethodInfo>>> result = new Dictionary<string, Dictionary<Type, List<MethodInfo>>>();
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #211 

<!-- Add short description of what has been fixed -->
Implemented methods as described by #211 .

The main method we are looking for here is [`CRUDcompatibleTypes()`](https://github.com/BHoM/BHoM_Adapter/pull/212/files#diff-aed398b26b0006559b947af68281cdddR85). This returns a `Dictionary<string,  Dictionary<Type, List<MethodInfo>>>`, that has:
- string key, one of: `Create`, `Read`, `Update`, `Delete`;
- value: another Dictionary with:
   - key: BHoM Type of with some CRUD method that supports it
   - value: list of CRUD methods compatible with that Type.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EuyegrQgtQlCvxyFw8L7ikQBkgksD0yYdjYRHA1cx3C9kg?e=A0gdN5
