### PR TITLE
Renamed PushType.FullCRUD to FullPush

### DIFF
--- a/Adapter_oM/Settings-Config/AdapterSettings.cs
+++ b/Adapter_oM/Settings-Config/AdapterSettings.cs
@@ -36,8 +36,8 @@ namespace BH.oM.Adapter
         [Description("If your Toolkit needs support for non-BHoM objects, set this to true.")]
         public bool WrapNonBHoMObjects { get; set; } = false;
 
-        [Description("If your Toolkit does not support the Full CRUD, you can select another behaviour here (e.g. CreateOnly).")]
-        public PushType DefaultPushType = PushType.FullCRUD;
+        [Description("If your Toolkit does not support the FullPush (FullCRUD method), you can select another behaviour here (e.g. CreateOnly).")]
+        public PushType DefaultPushType = PushType.FullPush;
 
         [Description("Deep clones the objects before Pushing them." +
             "As the objects get modified during the Push (e.g. their externalId is added to them)," +

--- a/Adapter_oM/enums/PushType.cs
+++ b/Adapter_oM/enums/PushType.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 
 namespace BH.oM.Adapter
 {
-    [Description("FullCRUD - Calls all CRUD methods as appropriate.\n" +
+    [Description("FullPush - Calls all CRUD methods as appropriate.\n" +
         "CreateOnly - Uses only the Create CRUD method to export the objects. This may create duplicates if the object already exists.\n" +
         "UpdateOnly - Uses only the Update CRUD method to update the objects in the external software. All other objects in the model are left untouched.\n" +
         "DeleteThenCreate - For all objects being Pushed, identifies their type, calls Delete to remove all of those types, then it Creates them.\n" +
@@ -37,7 +37,7 @@ namespace BH.oM.Adapter
     public enum PushType //add error message if not picked up --> compliance check for this?
     {
         [Description("Calls all CRUD methods as appropriate.")]
-        FullCRUD,
+        FullPush,
         [Description("Uses only the Create CRUD method to export the objects. This may create duplicates if the object already exists.")]
         CreateOnly,
         [Description("Uses only the Update CRUD method to update the objects in the external software.")]

--- a/BHoM_Adapter/AdapterActions/Push.cs
+++ b/BHoM_Adapter/AdapterActions/Push.cs
@@ -51,7 +51,7 @@ namespace BH.Adapter
             //                 SET-UP                  //
             // ----------------------------------------//
 
-            // If unset, set the pushType to AdapterSettings' value (base AdapterSettings default is FullCRUD).
+            // If unset, set the pushType to AdapterSettings' value (base AdapterSettings default is FullPush).
             if (pushType == PushType.AdapterDefault)
                 pushType = m_AdapterSettings.DefaultPushType;
 
@@ -77,7 +77,7 @@ namespace BH.Adapter
                 MethodInfo enumCastMethod_specificType = typeof(Enumerable).GetMethod("Cast").MakeGenericMethod(new[] { typeGroup.Key });
                 var objList_specificType = enumCastMethod_specificType.Invoke(typeGroup, new object[] { typeGroup });
 
-                if (pushType == PushType.FullCRUD)
+                if (pushType == PushType.FullPush)
                     success &= FullCRUD(objList_specificType as dynamic, pushType, tag, actionConfig);
                 else if (pushType == PushType.CreateOnly)
                 {

--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/UpdateOnly.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/UpdateOnly.cs
@@ -57,7 +57,7 @@ namespace BH.Adapter
                 var dependencyObjects = Engine.Adapter.Query.GetDependencyObjects<T>(newObjects, dependencyTypes, tag); //first-level dependencies
 
                 foreach (var depObj in dependencyObjects)
-                    if (!FullCRUD(depObj.Value as dynamic, PushType.FullCRUD, tag, actionConfig))
+                    if (!FullCRUD(depObj.Value as dynamic, PushType.FullPush, tag, actionConfig))
                         return false;
             }
 

--- a/File_Adapter/AdapterActions/Push.cs
+++ b/File_Adapter/AdapterActions/Push.cs
@@ -49,7 +49,7 @@ namespace BH.Adapter.FileAdapter
             // If unset, set the actionConfig to a new ActionConfig.
             actionConfig = actionConfig == null ? new ActionConfig() : actionConfig;
 
-            // If unset, set the pushType to AdapterSettings' value (base AdapterSettings default is FullCRUD).
+            // If unset, set the pushType to AdapterSettings' value (base AdapterSettings default is FullPush).
             if (pushType == PushType.AdapterDefault)
                 pushType = m_AdapterSettings.DefaultPushType;
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #206 

## NOTE: Dependant branches:
Adding do-not-merge because it will ripple through to:
- Revit: https://github.com/BHoM/Revit_Toolkit/blob/713433f96d56d397ebd048114bd0238534515311/Adapter_Revit_UI/AdapterActions/Push.cs
- ETABS: https://github.com/BHoM/ETABS_Toolkit/blob/42ed85347966bcfd907f62b01d250348870037c7/Etabs_Adapter/CRUD/Create/_Create.cs)

