### PR TITLE
Add error message for failing pushing of Loads

### DIFF
--- a/Structure_AdapterModules/ErrorMessages/ErrorMessages.cs
+++ b/Structure_AdapterModules/ErrorMessages/ErrorMessages.cs
@@ -82,11 +82,11 @@ namespace BH.Adapter.Modules.Structure
             string message;
 
             if (string.IsNullOrWhiteSpace(loadName))
-                message = "The " + objDesc + " assigned to " + anOrA + " " + loadDesc;
+                message = $"The {objDesc} assigned to {anOrA} {loadDesc}";
             else
-                message = "The " + objDesc + " assigned to the " + loadDesc + " named " + loadName;
+                message = $"The {objDesc} assigned to the {loadDesc} named {loadName}";
 
-            message += " being pushed does not contain any id-information and can not be identified by the software.\nPlease make sure all " + objDesc + " assigned to the " + loadDesc + " have been pulled from the package to ensure they contain the necessary information.";
+            message += $" being pushed does not contain any id-information and can not be identified by the software.\nPlease make sure all {objDesc} assigned to the {loadDesc} have been pulled from the package to ensure they contain the necessary information.";
 
             Engine.Reflection.Compute.RecordError(message);
         }

--- a/Structure_AdapterModules/ErrorMessages/ErrorMessages.cs
+++ b/Structure_AdapterModules/ErrorMessages/ErrorMessages.cs
@@ -72,8 +72,15 @@ namespace BH.Adapter.Modules.Structure
         {
             string loadDesc = loadType == null ? "load" : loadType.Name;
             string objDesc = objectType == null ? "objects" : objectType.Name + "s";
+            char[] vowels = { 'a', 'e', 'i', 'o', 'u', 'y' };
+            string anOrA;
+            if (vowels.Contains(loadDesc.ToLower().ToCharArray().First()))
+                anOrA = "an";
+            else
+                anOrA = "a";
 
-            Engine.Reflection.Compute.RecordError("The " + objDesc + " assigned to a " + loadDesc + " being pushed does not contain any id-information and can not be identified by the software.\nPlease make sure the " + objDesc + " assigned to the " + loadDesc + " have been pulled from the package to ensure they contain the necessary information.");
+
+            Engine.Reflection.Compute.RecordError("The " + objDesc + " assigned to " + anOrA + " " + loadDesc + " being pushed does not contain any id-information and can not be identified by the software.\nPlease make sure all " + objDesc + " assigned to the " + loadDesc + " have been pulled from the package to ensure they contain the necessary information.");
         }
 
         /***************************************************/

--- a/Structure_AdapterModules/ErrorMessages/ErrorMessages.cs
+++ b/Structure_AdapterModules/ErrorMessages/ErrorMessages.cs
@@ -23,6 +23,7 @@
 using System;
 using BH.oM.Structure.Requests;
 using BH.oM.Structure.Results;
+using BH.oM.Structure.Loads;
 using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -63,6 +64,23 @@ namespace BH.Adapter.Modules.Structure
                 message += " Please instead make use of the appropriate ResultRequest that gives more options for the result extraction.";
 
             Engine.Reflection.Compute.RecordError(message);
+        }
+
+        /***************************************************/
+
+        public static void LoadsWithoutObejctIdsAssignedError(Type loadType = null, Type objectType = null)
+        {
+            string loadDesc = loadType == null ? "load" : loadType.Name;
+            string objDesc = objectType == null ? "objects" : objectType.Name + "s";
+
+            Engine.Reflection.Compute.RecordError("The " + objDesc + " assigned to a " + loadDesc + " being pushed does not contain any id-information and can not be identified by the software.\nPlease make sure the " + objDesc + " assigned to the " + loadDesc + " have been pulled from the package to ensure they contain the necessary information.");
+        }
+
+        /***************************************************/
+
+        public static void LoadsWithoutObejctIdsAssignedError<T>(IElementLoad<T> load) where T : IBHoMObject
+        {
+            LoadsWithoutObejctIdsAssignedError(load.GetType(), typeof(T));
         }
 
         /***************************************************/

--- a/Structure_AdapterModules/ErrorMessages/ErrorMessages.cs
+++ b/Structure_AdapterModules/ErrorMessages/ErrorMessages.cs
@@ -68,7 +68,7 @@ namespace BH.Adapter.Modules.Structure
 
         /***************************************************/
 
-        public static void LoadsWithoutObejctIdsAssignedError(Type loadType = null, Type objectType = null)
+        public static void LoadsWithoutObejctIdsAssignedError(string loadName = "", Type loadType = null, Type objectType = null)
         {
             string loadDesc = loadType == null ? "load" : loadType.Name;
             string objDesc = objectType == null ? "objects" : objectType.Name + "s";
@@ -79,15 +79,23 @@ namespace BH.Adapter.Modules.Structure
             else
                 anOrA = "a";
 
+            string message;
 
-            Engine.Reflection.Compute.RecordError("The " + objDesc + " assigned to " + anOrA + " " + loadDesc + " being pushed does not contain any id-information and can not be identified by the software.\nPlease make sure all " + objDesc + " assigned to the " + loadDesc + " have been pulled from the package to ensure they contain the necessary information.");
+            if (string.IsNullOrWhiteSpace(loadName))
+                message = "The " + objDesc + " assigned to " + anOrA + " " + loadDesc;
+            else
+                message = "The " + objDesc + " assigned to the " + loadDesc + " named " + loadName;
+
+            message += " being pushed does not contain any id-information and can not be identified by the software.\nPlease make sure all " + objDesc + " assigned to the " + loadDesc + " have been pulled from the package to ensure they contain the necessary information.";
+
+            Engine.Reflection.Compute.RecordError(message);
         }
 
         /***************************************************/
 
         public static void LoadsWithoutObejctIdsAssignedError<T>(IElementLoad<T> load) where T : IBHoMObject
         {
-            LoadsWithoutObejctIdsAssignedError(load.GetType(), typeof(T));
+            LoadsWithoutObejctIdsAssignedError(load.Name, load.GetType(), typeof(T));
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #245 

<!-- Add short description of what has been fixed -->

Adds error message for pushing loads with no ids assigned to them.

Message with no name:

![image](https://user-images.githubusercontent.com/22005920/91979783-90acb800-ed26-11ea-8daf-ac9716eb83ed.png)

Message with name:

![image](https://user-images.githubusercontent.com/22005920/91981240-cd79ae80-ed28-11ea-8b23-bf87f2b7cf2f.png)


To be used by toolkits for better reporting on loads not being able to be pushed due to the objects lacking id information.

### Test files
<!-- Link to test files to validate the proposed changes -->



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->