### PR TITLE
BHoM_Adapter: add `NewGuid()` auto-initialiser to AdapterGuid

### DIFF
--- a/BHoM_Adapter/BHoMAdapter.cs
+++ b/BHoM_Adapter/BHoMAdapter.cs
@@ -60,7 +60,7 @@ namespace BH.Adapter
             // {typeof(Bar), new List<Type> { typeof(ISectionProperty), typeof(Node) } }
         };
 
-        public Guid AdapterGuid { get; set; }
+        public Guid AdapterGuid { get; set; } = Guid.NewGuid();
 
         /***************************************************/
         /**** Protected Fields                          ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #256

As title. Needed for BHoM_UI to correctly link the Event raised from adapters as explained by @adecler

<!-- Add short description of what has been fixed -->