### PR TITLE
Adapter_oM: ActionConfig stores a ComparisonConfig instead of DiffingConfig

### DIFF
--- a/Adapter_Engine/Query/GetComparerForType.cs
+++ b/Adapter_Engine/Query/GetComparerForType.cs
@@ -56,7 +56,7 @@ namespace BH.Engine.Adapter
                 return interfaceComparer.First().Value as IEqualityComparer<T>;
 
             if (actionConfig != null && actionConfig.AllowHashForComparing)
-                return new HashComparer<T>(actionConfig.DiffingConfig.ComparisonConfig); // by default the hash doesn't consider GUIDs, Fragments and CustomData. You can set different exceptions in the ActionConfig's DiffConfig.
+                return new HashComparer<T>(actionConfig.ComparisonConfig); // by default the hash doesn't consider GUIDs, Fragments and CustomData. You can set different exceptions in the ActionConfig's DiffConfig.
 
             return EqualityComparer<T>.Default;
         }

--- a/Adapter_oM/Adapter_oM.csproj
+++ b/Adapter_oM/Adapter_oM.csproj
@@ -87,7 +87,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings-Config\ActionConfig.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="Versioning40.json" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/Adapter_oM/Settings-Config/ActionConfig.cs
+++ b/Adapter_oM/Settings-Config/ActionConfig.cs
@@ -43,7 +43,7 @@ namespace BH.oM.Adapter
         public virtual bool AllowHashForComparing { get; set; } = false;
 
         [Description("Configurations for the Diffing hashing. Requires `AllowHashForComparing` to be set to true.")]
-        public virtual DiffingConfig DiffingConfig { get; set; } = new DiffingConfig();
+        public virtual ComparisonConfig ComparisonConfig { get; set; } = new ComparisonConfig();
     }
 }
 

--- a/Adapter_oM/Versioning40.json
+++ b/Adapter_oM/Versioning40.json
@@ -1,9 +1,9 @@
 {
     "Property": {
         "ToNew": {
-            "BH.oM.Adapter.ActionConfig.DiffingConfig": "BH.oM.Adapter.ActionConfig.ComparisonConfig"
+            "BH.oM.Adapter.ActionConfig.DiffConfig": "BH.oM.Adapter.ActionConfig.ComparisonConfig"
         },
         "ToOld": {
-            "BH.oM.Adapter.ActionConfig.ComparisonConfig": "BH.oM.Adapter.ActionConfig.DiffingConfig"
+            "BH.oM.Adapter.ActionConfig.ComparisonConfig": "BH.oM.Adapter.ActionConfig.DiffConfig"
         }
     }

--- a/Adapter_oM/Versioning40.json
+++ b/Adapter_oM/Versioning40.json
@@ -1,0 +1,9 @@
+{
+    "Property": {
+        "ToNew": {
+            "BH.oM.Adapter.ActionConfig.DiffingConfig": "BH.oM.Adapter.ActionConfig.ComparisonConfig"
+        },
+        "ToOld": {
+            "BH.oM.Adapter.ActionConfig.ComparisonConfig": "BH.oM.Adapter.ActionConfig.DiffingConfig"
+        }
+    }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #271

<!-- Add short description of what has been fixed -->

Minor change that should help fixing the Versioning issue with all `ActionConfig`s.
It could be that currently Versioning is failing because there was substantial change in the `DiffingConfig` (it was renamed from "DiffConfig" and several properties changed; I missed to add Versioning for this in the ActionConfig).

This aligns the ActionConfig correctly to those changes: `DiffingConfig` is not needed in ActionConfig; instead we use the new `ComparisonConfig` object. This also adds the Versioning file.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->