### PR TITLE
Copy orientation support for nodes

### DIFF
--- a/Structure_AdapterModules/CopyNodeProperties.cs
+++ b/Structure_AdapterModules/CopyNodeProperties.cs
@@ -40,6 +40,10 @@ namespace BH.Adapter.Modules
             // If source is constrained and target is not, add source constraint to target
             if (source.Support != null && target.Support == null)
                 target.Support = source.Support;
+
+            // If source has a defined orientation and target does not, add local orientation from the source
+            if (source.Orientation != null && target.Orientation == null)
+                target.Orientation = source.Orientation;
         }
     }
 }

--- a/core.txt
+++ b/core.txt
@@ -1,1 +1,0 @@
-BHoM/BHoM_UI


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #285 

<!-- Add short description of what has been fixed -->

Done is support of https://github.com/BHoM/GSA_Toolkit/pull/225 for example.

Nodes to check if the source node has a set coordinate system while the node being pushed does not. Important if pushing support before meshes/bars for example to keep the pre-set coordinates in the model.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->