### PR TITLE
Adapter_Engine: Avoid signature duplication for AdapterId() methods

### DIFF
--- a/Adapter_Engine/Adapter_Engine.csproj
+++ b/Adapter_Engine/Adapter_Engine.csproj
@@ -87,6 +87,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Query\AdapterIds.cs" />
     <Compile Include="Query\HasAdapterIdFragment.cs" />
     <Compile Include="Query\AdapterId.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Adapter_Engine/Query/AdapterId.cs
+++ b/Adapter_Engine/Query/AdapterId.cs
@@ -39,32 +39,30 @@ namespace BH.Engine.Adapter
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static object AdapterId(this IBHoMObject bHoMObject, Type adapterIdFragmentType)
+        public static T AdapterId<T>(this IBHoMObject bHoMObject, Type adapterIdFragmentType)
         {
+            object id = null;
+
             if (!typeof(IAdapterId).IsAssignableFrom(adapterIdFragmentType))
             {
                 BH.Engine.Reflection.Compute.RecordError($"The `{adapterIdFragmentType.Name}` is not a valid `{typeof(IAdapterId).Name}`.");
-                return null;
+                return default(T);
             }
 
             List<IAdapterId> fragmentList = bHoMObject.GetAllFragments(adapterIdFragmentType).OfType<IAdapterId>().ToList();
 
-            if (fragmentList.Count != 0)
+            if (fragmentList.Count > 0)
             {
                 IEnumerable<object> ids = fragmentList.Select(f => f.Id);
 
                 if (ids.Count() == 1)
-                    return ids.First();
+                    id = ids.First();
                 else
-                    return ids;
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"A total of {ids.Count()} different IdFragments of type {adapterIdFragmentType.Name} were found on the object. Cannot return just one of them.");
+                    return default(T);
+                }
             }
-            else
-                return null;
-        }
-
-        public static T AdapterId<T>(this IBHoMObject bHoMObject, Type adapterIdFragmentType)
-        {
-            object id = AdapterId(bHoMObject, adapterIdFragmentType);
 
             if (id == null)
             {

--- a/Adapter_Engine/Query/AdapterId.cs
+++ b/Adapter_Engine/Query/AdapterId.cs
@@ -39,6 +39,7 @@ namespace BH.Engine.Adapter
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [PreviousVersion("4.0", "BH.Engine.Adapter.Query.AdapterId<T>(BH.oM.Base.IBHoMObject, Type adapterIdFragmentType)")]
         [Description("Returns the BHoMObject's Id of the provided FragmentType, casted to its type.\n" +
             "If more than one matching IdFragment is found, an error is returned.")]
         [Input("notFoundWarning", "If true, a Warning is issued when no matching ID is found.")]

--- a/Adapter_Engine/Query/AdapterId.cs
+++ b/Adapter_Engine/Query/AdapterId.cs
@@ -39,32 +39,10 @@ namespace BH.Engine.Adapter
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static object AdapterId(this IBHoMObject bHoMObject, Type adapterIdFragmentType)
-        {
-            if (!typeof(IAdapterId).IsAssignableFrom(adapterIdFragmentType))
-            {
-                BH.Engine.Reflection.Compute.RecordError($"The `{adapterIdFragmentType.Name}` is not a valid `{typeof(IAdapterId).Name}`.");
-                return null;
-            }
-
-            List<IAdapterId> fragmentList = bHoMObject.GetAllFragments(adapterIdFragmentType).OfType<IAdapterId>().ToList();
-
-            if (fragmentList.Count != 0)
-            {
-                IEnumerable<object> ids = fragmentList.Select(f => f.Id);
-
-                if (ids.Count() == 1)
-                    return ids.First();
-                else
-                    return ids;
-            }
-            else
-                return null;
-        }
-
+        [Description("Returns the BHoMObject's Id of the provided FragmentType, casted to its type. If more than one matching IdFragment is found, an error is returned.")]
         public static T AdapterId<T>(this IBHoMObject bHoMObject, Type adapterIdFragmentType)
         {
-            object id = AdapterId(bHoMObject, adapterIdFragmentType);
+            object id = AdapterIds(bHoMObject, adapterIdFragmentType);
 
             if (id == null)
             {
@@ -86,7 +64,6 @@ namespace BH.Engine.Adapter
                 return default(T);
             }
         }
-
     }
 }
 

--- a/Adapter_Engine/Query/AdapterId.cs
+++ b/Adapter_Engine/Query/AdapterId.cs
@@ -60,7 +60,7 @@ namespace BH.Engine.Adapter
                 return (T)id;
             }
 
-            if (id is IEnumerable)
+            if (id is IEnumerable && !(id is string))
             {
                 BH.Engine.Reflection.Compute.RecordWarning($"More than one matching ID was found for type {adapterIdFragmentType.Name}.");
                 return default(T);
@@ -78,4 +78,3 @@ namespace BH.Engine.Adapter
         }
     }
 }
-

--- a/Adapter_Engine/Query/AdapterId.cs
+++ b/Adapter_Engine/Query/AdapterId.cs
@@ -29,7 +29,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
-
+using System.Collections;
 
 namespace BH.Engine.Adapter
 {
@@ -54,6 +54,13 @@ namespace BH.Engine.Adapter
             {
                 return (T)id;
             }
+
+            if (id is IEnumerable)
+            {
+                BH.Engine.Reflection.Compute.RecordWarning($"More than one matching ID was found for type {adapterIdFragmentType.Name}.");
+                return default(T);
+            }
+
             try
             {
                 return (T)Convert.ChangeType(id, typeof(T));

--- a/Adapter_Engine/Query/AdapterId.cs
+++ b/Adapter_Engine/Query/AdapterId.cs
@@ -39,30 +39,32 @@ namespace BH.Engine.Adapter
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static T AdapterId<T>(this IBHoMObject bHoMObject, Type adapterIdFragmentType)
+        public static object AdapterId(this IBHoMObject bHoMObject, Type adapterIdFragmentType)
         {
-            object id = null;
-
             if (!typeof(IAdapterId).IsAssignableFrom(adapterIdFragmentType))
             {
                 BH.Engine.Reflection.Compute.RecordError($"The `{adapterIdFragmentType.Name}` is not a valid `{typeof(IAdapterId).Name}`.");
-                return default(T);
+                return null;
             }
 
             List<IAdapterId> fragmentList = bHoMObject.GetAllFragments(adapterIdFragmentType).OfType<IAdapterId>().ToList();
 
-            if (fragmentList.Count > 0)
+            if (fragmentList.Count != 0)
             {
                 IEnumerable<object> ids = fragmentList.Select(f => f.Id);
 
                 if (ids.Count() == 1)
-                    id = ids.First();
+                    return ids.First();
                 else
-                {
-                    BH.Engine.Reflection.Compute.RecordError($"A total of {ids.Count()} different IdFragments of type {adapterIdFragmentType.Name} were found on the object. Cannot return just one of them.");
-                    return default(T);
-                }
+                    return ids;
             }
+            else
+                return null;
+        }
+
+        public static T AdapterId<T>(this IBHoMObject bHoMObject, Type adapterIdFragmentType)
+        {
+            object id = AdapterId(bHoMObject, adapterIdFragmentType);
 
             if (id == null)
             {

--- a/Adapter_Engine/Query/AdapterId.cs
+++ b/Adapter_Engine/Query/AdapterId.cs
@@ -39,14 +39,18 @@ namespace BH.Engine.Adapter
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Returns the BHoMObject's Id of the provided FragmentType, casted to its type. If more than one matching IdFragment is found, an error is returned.")]
-        public static T AdapterId<T>(this IBHoMObject bHoMObject, Type adapterIdFragmentType)
+        [Description("Returns the BHoMObject's Id of the provided FragmentType, casted to its type.\n" +
+            "If more than one matching IdFragment is found, an error is returned.")]
+        [Input("notFoundWarning", "If true, a Warning is issued when no matching ID is found.")]
+        public static T AdapterId<T>(this IBHoMObject bHoMObject, Type adapterIdFragmentType, bool notFoundWarning = true)
         {
             object id = AdapterIds(bHoMObject, adapterIdFragmentType);
 
             if (id == null)
             {
-                BH.Engine.Reflection.Compute.RecordWarning($"AdapterId is null or missing for an object of type {bHoMObject.GetType().Name}.");
+                if (notFoundWarning)
+                    BH.Engine.Reflection.Compute.RecordWarning($"AdapterId is null or missing for an object of type {bHoMObject.GetType().Name}.");
+
                 return default(T);
             }
 

--- a/Adapter_Engine/Query/AdapterIds.cs
+++ b/Adapter_Engine/Query/AdapterIds.cs
@@ -39,7 +39,9 @@ namespace BH.Engine.Adapter
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Returns the BHoMObject's Id of the provided FragmentType. If more than one matching IdFragment is found, the method returns a List of all Ids of that type.")]
+        [Description("Returns the BHoMObject's Id of the provided FragmentType. " +
+            "If more than one matching IdFragment is found, the method returns a List of all Ids of that type." +
+            "If none is found, `null` is returned.")]
         public static object AdapterIds(this IBHoMObject bHoMObject, Type adapterIdFragmentType)
         {
             if (!typeof(IAdapterId).IsAssignableFrom(adapterIdFragmentType))

--- a/Adapter_Engine/Query/AdapterIds.cs
+++ b/Adapter_Engine/Query/AdapterIds.cs
@@ -39,6 +39,7 @@ namespace BH.Engine.Adapter
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [PreviousVersion("4.0", "BH.Engine.Adapter.Query.AdapterId(BH.oM.Base.IBHoMObject, Type adapterIdFragmentType)")]
         [Description("Returns the BHoMObject's Id of the provided FragmentType. " +
             "If more than one matching IdFragment is found, the method returns a List of all Ids of that type." +
             "If none is found, `null` is returned.")]

--- a/Adapter_Engine/Query/AdapterIds.cs
+++ b/Adapter_Engine/Query/AdapterIds.cs
@@ -42,7 +42,7 @@ namespace BH.Engine.Adapter
         [Description("Returns the BHoMObject's Id of the provided FragmentType. " +
             "If more than one matching IdFragment is found, the method returns a List of all Ids of that type." +
             "If none is found, `null` is returned.")]
-        public static object AdapterIds(this IBHoMObject bHoMObject, Type adapterIdFragmentType)
+        public static object AdapterIds(this IBHoMObject bHoMObject, Type adapterIdFragmentType = null)
         {
             if (!typeof(IAdapterId).IsAssignableFrom(adapterIdFragmentType))
             {

--- a/Adapter_Engine/Query/AdapterIds.cs
+++ b/Adapter_Engine/Query/AdapterIds.cs
@@ -20,38 +20,48 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Reflection;
 using BH.oM.Adapter;
 using BH.oM.Base;
-using BH.Engine.Adapter;
 using BH.Engine.Base;
-using BH.oM.Data.Collections;
+using BH.oM.Reflection.Attributes;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 
-namespace BH.Adapter
+
+namespace BH.Engine.Adapter
 {
-    public abstract partial class BHoMAdapter
+    public static partial class Query
     {
-        public void SetAdapterId(IBHoMObject bHoMObject, object id)
-        {
-            bHoMObject.SetAdapterId(AdapterIdFragmentType, id);
-        }
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
 
-        public object GetAdapterId(IBHoMObject bHoMObject)
+        [Description("Returns the BHoMObject's Id of the provided FragmentType. If more than one matching IdFragment is found, the method returns a List of all Ids of that type.")]
+        public static object AdapterIds(this IBHoMObject bHoMObject, Type adapterIdFragmentType)
         {
-            return bHoMObject.AdapterIds(AdapterIdFragmentType);
-        }
+            if (!typeof(IAdapterId).IsAssignableFrom(adapterIdFragmentType))
+            {
+                BH.Engine.Reflection.Compute.RecordError($"The `{adapterIdFragmentType.Name}` is not a valid `{typeof(IAdapterId).Name}`.");
+                return null;
+            }
 
-        public T GetAdapterId<T>(IBHoMObject bHoMObject)
-        {
-            return bHoMObject.AdapterId<T>(AdapterIdFragmentType);
+            List<IAdapterId> fragmentList = bHoMObject.GetAllFragments(adapterIdFragmentType).OfType<IAdapterId>().ToList();
+
+            if (fragmentList.Count != 0)
+            {
+                IEnumerable<object> ids = fragmentList.Select(f => f.Id);
+
+                if (ids.Count() == 1)
+                    return ids.First();
+                else
+                    return ids;
+            }
+            else
+                return null;
         }
     }
 }
-
 

--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/FullCRUD.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/FullCRUD.cs
@@ -82,7 +82,7 @@ namespace BH.Adapter
                 // All objects read from the model are to be deleted. 
                 // Note that this means that only objects of the same type of the objects being pushed will be deleted.
                 if (readObjects.Any())
-                    IDelete(typeof(T), readObjects.Select(obj => AdapterId(obj, AdapterIdFragmentType)), actionConfig);
+                    IDelete(typeof(T), readObjects.Select(obj => obj.AdapterId(AdapterIdFragmentType)), actionConfig);
 
                 objectsToCreate = newObjects;
             }
@@ -178,11 +178,11 @@ namespace BH.Adapter
 
             // Extract the adapterIds from the toBeDeleted and call Delete() for all of them.
             if (pushType != PushType.UpdateOrCreateOnly && toBeDeleted != null && toBeDeleted.Any())
-                IDelete(typeof(T), toBeDeleted.Select(obj => AdapterId(obj, AdapterIdFragmentType)), actionConfig);
+                IDelete(typeof(T), toBeDeleted.Select(obj => obj.AdapterId(AdapterIdFragmentType)), actionConfig);
 
             // Update the tags for the rest of the existing objects in the model
             IUpdateTags(typeof(T),
-                readObjs_exclusive.Where(x => x.Tags.Count > 0).Select(x => AdapterId(x, AdapterIdFragmentType)),
+                readObjs_exclusive.Where(x => x.Tags.Count > 0).Select(x => x.AdapterId(AdapterIdFragmentType)),
                 readObjs_exclusive.Where(x => x.Tags.Count > 0).Select(x => x.Tags),
                 actionConfig);
 
@@ -211,14 +211,17 @@ namespace BH.Adapter
                 //For CreateNonExisting, the overlap objects are just kept, and not updated. To make sure tag functionality works though, 
                 //The obejcts need to get their tags (if any) updated.
                 IUpdateTags(typeof(T),
-                    diagram.Intersection.Where(x => x.Item1.Tags.Count > 0).Select(x => AdapterId(x.Item1, AdapterIdFragmentType)),
+                    diagram.Intersection.Where(x => x.Item1.Tags.Count > 0).Select(x => x.Item1.AdapterId(AdapterIdFragmentType)),
                     diagram.Intersection.Where(x => x.Item1.Tags.Count > 0).Select(x => x.Item1.Tags),
                     actionConfig);
             }
 
+
             // Return the objectsToPush that do not have any overlap with the existing ones; those will need to be created
             return objsToPush_exclusive;
         }
+
+
     }
 }
 

--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/FullCRUD.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/FullCRUD.cs
@@ -82,7 +82,7 @@ namespace BH.Adapter
                 // All objects read from the model are to be deleted. 
                 // Note that this means that only objects of the same type of the objects being pushed will be deleted.
                 if (readObjects.Any())
-                    IDelete(typeof(T), readObjects.Select(obj => obj.AdapterId(AdapterIdFragmentType)), actionConfig);
+                    IDelete(typeof(T), readObjects.Select(obj => AdapterId(obj, AdapterIdFragmentType)), actionConfig);
 
                 objectsToCreate = newObjects;
             }
@@ -178,11 +178,11 @@ namespace BH.Adapter
 
             // Extract the adapterIds from the toBeDeleted and call Delete() for all of them.
             if (pushType != PushType.UpdateOrCreateOnly && toBeDeleted != null && toBeDeleted.Any())
-                IDelete(typeof(T), toBeDeleted.Select(obj => obj.AdapterId(AdapterIdFragmentType)), actionConfig);
+                IDelete(typeof(T), toBeDeleted.Select(obj => AdapterId(obj, AdapterIdFragmentType)), actionConfig);
 
             // Update the tags for the rest of the existing objects in the model
             IUpdateTags(typeof(T),
-                readObjs_exclusive.Where(x => x.Tags.Count > 0).Select(x => x.AdapterId(AdapterIdFragmentType)),
+                readObjs_exclusive.Where(x => x.Tags.Count > 0).Select(x => AdapterId(x, AdapterIdFragmentType)),
                 readObjs_exclusive.Where(x => x.Tags.Count > 0).Select(x => x.Tags),
                 actionConfig);
 
@@ -211,17 +211,14 @@ namespace BH.Adapter
                 //For CreateNonExisting, the overlap objects are just kept, and not updated. To make sure tag functionality works though, 
                 //The obejcts need to get their tags (if any) updated.
                 IUpdateTags(typeof(T),
-                    diagram.Intersection.Where(x => x.Item1.Tags.Count > 0).Select(x => x.Item1.AdapterId(AdapterIdFragmentType)),
+                    diagram.Intersection.Where(x => x.Item1.Tags.Count > 0).Select(x => AdapterId(x.Item1, AdapterIdFragmentType)),
                     diagram.Intersection.Where(x => x.Item1.Tags.Count > 0).Select(x => x.Item1.Tags),
                     actionConfig);
             }
 
-
             // Return the objectsToPush that do not have any overlap with the existing ones; those will need to be created
             return objsToPush_exclusive;
         }
-
-
     }
 }
 

--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/FullCRUD.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/FullCRUD.cs
@@ -82,7 +82,7 @@ namespace BH.Adapter
                 // All objects read from the model are to be deleted. 
                 // Note that this means that only objects of the same type of the objects being pushed will be deleted.
                 if (readObjects.Any())
-                    IDelete(typeof(T), readObjects.Select(obj => obj.AdapterId(AdapterIdFragmentType)), actionConfig);
+                    IDelete(typeof(T), readObjects.Select(obj => obj.AdapterIds(AdapterIdFragmentType)), actionConfig);
 
                 objectsToCreate = newObjects;
             }
@@ -178,11 +178,11 @@ namespace BH.Adapter
 
             // Extract the adapterIds from the toBeDeleted and call Delete() for all of them.
             if (pushType != PushType.UpdateOrCreateOnly && toBeDeleted != null && toBeDeleted.Any())
-                IDelete(typeof(T), toBeDeleted.Select(obj => obj.AdapterId(AdapterIdFragmentType)), actionConfig);
+                IDelete(typeof(T), toBeDeleted.Select(obj => obj.AdapterIds(AdapterIdFragmentType)), actionConfig);
 
             // Update the tags for the rest of the existing objects in the model
             IUpdateTags(typeof(T),
-                readObjs_exclusive.Where(x => x.Tags.Count > 0).Select(x => x.AdapterId(AdapterIdFragmentType)),
+                readObjs_exclusive.Where(x => x.Tags.Count > 0).Select(x => x.AdapterIds(AdapterIdFragmentType)),
                 readObjs_exclusive.Where(x => x.Tags.Count > 0).Select(x => x.Tags),
                 actionConfig);
 
@@ -211,7 +211,7 @@ namespace BH.Adapter
                 //For CreateNonExisting, the overlap objects are just kept, and not updated. To make sure tag functionality works though, 
                 //The obejcts need to get their tags (if any) updated.
                 IUpdateTags(typeof(T),
-                    diagram.Intersection.Where(x => x.Item1.Tags.Count > 0).Select(x => x.Item1.AdapterId(AdapterIdFragmentType)),
+                    diagram.Intersection.Where(x => x.Item1.Tags.Count > 0).Select(x => x.Item1.AdapterIds(AdapterIdFragmentType)),
                     diagram.Intersection.Where(x => x.Item1.Tags.Count > 0).Select(x => x.Item1.Tags),
                     actionConfig);
             }

--- a/BHoM_Adapter/CRUD/IDelete.cs
+++ b/BHoM_Adapter/CRUD/IDelete.cs
@@ -87,12 +87,12 @@ namespace BH.Adapter
                 IEnumerable<IBHoMObject> withTag = Read(type, tag, actionConfig);
 
                 // Get indices of all with that tag only
-                IEnumerable<object> ids = withTag.Where(x => x.Tags.Count == 1).Select(x => AdapterId(x, AdapterIdFragmentType)).OrderBy(x => x);
+                IEnumerable<object> ids = withTag.Where(x => x.Tags.Count == 1).Select(x => x.AdapterId(AdapterIdFragmentType)).OrderBy(x => x);
                 IDelete(type, ids);
 
                 // Remove tag if other tags as well
                 IEnumerable<IBHoMObject> multiTags = withTag.Where(x => x.Tags.Count > 1);
-                IUpdateTags(type, multiTags.Select(x => AdapterId(x, AdapterIdFragmentType)), multiTags.Select(x => x.Tags), actionConfig);
+                IUpdateTags(type, multiTags.Select(x => x.AdapterId(AdapterIdFragmentType)), multiTags.Select(x => x.Tags), actionConfig);
 
                 return ids.Count();
             }

--- a/BHoM_Adapter/CRUD/IDelete.cs
+++ b/BHoM_Adapter/CRUD/IDelete.cs
@@ -87,12 +87,12 @@ namespace BH.Adapter
                 IEnumerable<IBHoMObject> withTag = Read(type, tag, actionConfig);
 
                 // Get indices of all with that tag only
-                IEnumerable<object> ids = withTag.Where(x => x.Tags.Count == 1).Select(x => x.AdapterId(AdapterIdFragmentType)).OrderBy(x => x);
+                IEnumerable<object> ids = withTag.Where(x => x.Tags.Count == 1).Select(x => x.AdapterIds(AdapterIdFragmentType)).OrderBy(x => x);
                 IDelete(type, ids);
 
                 // Remove tag if other tags as well
                 IEnumerable<IBHoMObject> multiTags = withTag.Where(x => x.Tags.Count > 1);
-                IUpdateTags(type, multiTags.Select(x => x.AdapterId(AdapterIdFragmentType)), multiTags.Select(x => x.Tags), actionConfig);
+                IUpdateTags(type, multiTags.Select(x => x.AdapterIds(AdapterIdFragmentType)), multiTags.Select(x => x.Tags), actionConfig);
 
                 return ids.Count();
             }

--- a/BHoM_Adapter/CRUD/IDelete.cs
+++ b/BHoM_Adapter/CRUD/IDelete.cs
@@ -87,12 +87,12 @@ namespace BH.Adapter
                 IEnumerable<IBHoMObject> withTag = Read(type, tag, actionConfig);
 
                 // Get indices of all with that tag only
-                IEnumerable<object> ids = withTag.Where(x => x.Tags.Count == 1).Select(x => x.AdapterId(AdapterIdFragmentType)).OrderBy(x => x);
+                IEnumerable<object> ids = withTag.Where(x => x.Tags.Count == 1).Select(x => AdapterId(x, AdapterIdFragmentType)).OrderBy(x => x);
                 IDelete(type, ids);
 
                 // Remove tag if other tags as well
                 IEnumerable<IBHoMObject> multiTags = withTag.Where(x => x.Tags.Count > 1);
-                IUpdateTags(type, multiTags.Select(x => x.AdapterId(AdapterIdFragmentType)), multiTags.Select(x => x.Tags), actionConfig);
+                IUpdateTags(type, multiTags.Select(x => AdapterId(x, AdapterIdFragmentType)), multiTags.Select(x => x.Tags), actionConfig);
 
                 return ids.Count();
             }

--- a/BHoM_Adapter/CRUD/IUpdate.cs
+++ b/BHoM_Adapter/CRUD/IUpdate.cs
@@ -52,7 +52,7 @@ namespace BH.Adapter
             Type objectType = typeof(T);
             if (m_AdapterSettings.UseAdapterId && typeof(IBHoMObject).IsAssignableFrom(objectType))
             {
-                IDelete(typeof(T), objects.Select(x => ((IBHoMObject)x).AdapterId(AdapterIdFragmentType)), actionConfig);
+                IDelete(typeof(T), objects.Select(x => ((IBHoMObject)x).AdapterIds(AdapterIdFragmentType)), actionConfig);
             }
             return ICreate(objects, actionConfig);
         }

--- a/BHoM_Adapter/CRUD/IUpdate.cs
+++ b/BHoM_Adapter/CRUD/IUpdate.cs
@@ -52,7 +52,7 @@ namespace BH.Adapter
             Type objectType = typeof(T);
             if (m_AdapterSettings.UseAdapterId && typeof(IBHoMObject).IsAssignableFrom(objectType))
             {
-                IDelete(typeof(T), objects.Select(x => ((IBHoMObject)x).AdapterId(AdapterIdFragmentType)), actionConfig);
+                IDelete(typeof(T), objects.Select(x => AdapterId(((IBHoMObject)x), AdapterIdFragmentType)), actionConfig);
             }
             return ICreate(objects, actionConfig);
         }

--- a/BHoM_Adapter/CRUD/IUpdate.cs
+++ b/BHoM_Adapter/CRUD/IUpdate.cs
@@ -52,7 +52,7 @@ namespace BH.Adapter
             Type objectType = typeof(T);
             if (m_AdapterSettings.UseAdapterId && typeof(IBHoMObject).IsAssignableFrom(objectType))
             {
-                IDelete(typeof(T), objects.Select(x => AdapterId(((IBHoMObject)x), AdapterIdFragmentType)), actionConfig);
+                IDelete(typeof(T), objects.Select(x => ((IBHoMObject)x).AdapterId(AdapterIdFragmentType)), actionConfig);
             }
             return ICreate(objects, actionConfig);
         }

--- a/BHoM_Adapter/HelperMethods/AdapterId.cs
+++ b/BHoM_Adapter/HelperMethods/AdapterId.cs
@@ -37,30 +37,6 @@ namespace BH.Adapter
 {
     public abstract partial class BHoMAdapter
     {
-        [Description("Returns the BHoMObject's Id of the provided FragmentType. If more than one matching IdFragment is found, the method returns a List of all Ids of that type.")]
-        public static object AdapterId(IBHoMObject bHoMObject, Type adapterIdFragmentType)
-        {
-            if (!typeof(IAdapterId).IsAssignableFrom(adapterIdFragmentType))
-            {
-                BH.Engine.Reflection.Compute.RecordError($"The `{adapterIdFragmentType.Name}` is not a valid `{typeof(IAdapterId).Name}`.");
-                return null;
-            }
-
-            List<IAdapterId> fragmentList = bHoMObject.GetAllFragments(adapterIdFragmentType).OfType<IAdapterId>().ToList();
-
-            if (fragmentList.Count != 0)
-            {
-                IEnumerable<object> ids = fragmentList.Select(f => f.Id);
-
-                if (ids.Count() == 1)
-                    return ids.First();
-                else
-                    return ids.ToList();
-            }
-            else
-                return null;
-        }
-
         public void SetAdapterId(IBHoMObject bHoMObject, object id)
         {
             bHoMObject.SetAdapterId(AdapterIdFragmentType, id);
@@ -68,7 +44,7 @@ namespace BH.Adapter
 
         public object GetAdapterId(IBHoMObject bHoMObject)
         {
-            return AdapterId(bHoMObject, AdapterIdFragmentType);
+            return bHoMObject.AdapterId(AdapterIdFragmentType);
         }
 
         public T GetAdapterId<T>(IBHoMObject bHoMObject)

--- a/BHoM_Adapter/HelperMethods/AdapterId.cs
+++ b/BHoM_Adapter/HelperMethods/AdapterId.cs
@@ -37,6 +37,30 @@ namespace BH.Adapter
 {
     public abstract partial class BHoMAdapter
     {
+        [Description("Returns the BHoMObject's Id of the provided FragmentType. If more than one matching IdFragment is found, the method returns a List of all Ids of that type.")]
+        public static object AdapterId(IBHoMObject bHoMObject, Type adapterIdFragmentType)
+        {
+            if (!typeof(IAdapterId).IsAssignableFrom(adapterIdFragmentType))
+            {
+                BH.Engine.Reflection.Compute.RecordError($"The `{adapterIdFragmentType.Name}` is not a valid `{typeof(IAdapterId).Name}`.");
+                return null;
+            }
+
+            List<IAdapterId> fragmentList = bHoMObject.GetAllFragments(adapterIdFragmentType).OfType<IAdapterId>().ToList();
+
+            if (fragmentList.Count != 0)
+            {
+                IEnumerable<object> ids = fragmentList.Select(f => f.Id);
+
+                if (ids.Count() == 1)
+                    return ids.First();
+                else
+                    return ids.ToList();
+            }
+            else
+                return null;
+        }
+
         public void SetAdapterId(IBHoMObject bHoMObject, object id)
         {
             bHoMObject.SetAdapterId(AdapterIdFragmentType, id);
@@ -44,7 +68,7 @@ namespace BH.Adapter
 
         public object GetAdapterId(IBHoMObject bHoMObject)
         {
-            return bHoMObject.AdapterId(AdapterIdFragmentType);
+            return AdapterId(bHoMObject, AdapterIdFragmentType);
         }
 
         public T GetAdapterId<T>(IBHoMObject bHoMObject)

--- a/BHoM_Adapter/HelperMethods/CopyBHoMObjectProperties.cs
+++ b/BHoM_Adapter/HelperMethods/CopyBHoMObjectProperties.cs
@@ -50,7 +50,7 @@ namespace BH.Adapter
 
             // Get id of the source and port it to the target
             if (source.HasAdapterIdFragment(AdapterIdFragmentType))
-                target.SetAdapterId(AdapterIdFragmentType, source.AdapterId(AdapterIdFragmentType));
+                target.SetAdapterId(AdapterIdFragmentType, AdapterId(source, AdapterIdFragmentType));
         }
     }
 }

--- a/BHoM_Adapter/HelperMethods/CopyBHoMObjectProperties.cs
+++ b/BHoM_Adapter/HelperMethods/CopyBHoMObjectProperties.cs
@@ -50,7 +50,7 @@ namespace BH.Adapter
 
             // Get id of the source and port it to the target
             if (source.HasAdapterIdFragment(AdapterIdFragmentType))
-                target.SetAdapterId(AdapterIdFragmentType, source.AdapterId(AdapterIdFragmentType));
+                target.SetAdapterId(AdapterIdFragmentType, source.AdapterIds(AdapterIdFragmentType));
         }
     }
 }

--- a/BHoM_Adapter/HelperMethods/CopyBHoMObjectProperties.cs
+++ b/BHoM_Adapter/HelperMethods/CopyBHoMObjectProperties.cs
@@ -50,7 +50,7 @@ namespace BH.Adapter
 
             // Get id of the source and port it to the target
             if (source.HasAdapterIdFragment(AdapterIdFragmentType))
-                target.SetAdapterId(AdapterIdFragmentType, AdapterId(source, AdapterIdFragmentType));
+                target.SetAdapterId(AdapterIdFragmentType, source.AdapterId(AdapterIdFragmentType));
         }
     }
 }

--- a/core.txt
+++ b/core.txt
@@ -1,0 +1,1 @@
+BHoM/BHoM_UI


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

## Dependant PRs

- SAP2000 needs alignment to this PR, done in https://github.com/BHoM/SAP2000_Toolkit/pull/200.
- ETABS needs alignment to this PR, done in https://github.com/BHoM/ETABS_Toolkit/pull/380
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #284
Closes #288

<!-- Add short description of what has been fixed -->
This PR revises the two methods that get the `AdapterId` of a specific fragment Type out of a given BHoMObject.
Both methods are useful and need to be maintained, but due to the conflict explained in #284 they had to be renamed/revised.

We have:
1. a non generic method `AdapterId(this BHoMObject, ...)` that returns `object`. This gathers all IDs that implement a certain fragment type. If multiple IDs are found, a List is returned. If one Id is found, only that is returned.  
This method was renamed to `AdapterIds<T>(this BHoMObject, ...)` (note the **s**).
2. a generic method that does a similar thing, but also tries to cast to the requested type `<T>`. This method will return an error if multiple IDs are found. This method was slightly modified to expose more useful errors/warnings and better distinguish its function from the other one. The method was not renamed.

There are only 2 Toolkits that requires alignment (SAP2000/ETABS) because they have a reference to the renamed method (1).

All other Adapter Toolkits needs to be tested to make sure that the functionality is still working as expected.


### Test files
<!-- Link to test files to validate the proposed changes -->
Needs testing of existing functionality on all Adapters. 

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->