### PR TITLE
Adapter_Engine: add reference for `HashComparer`

### DIFF
--- a/Adapter_Engine/Query/GetComparerForType.cs
+++ b/Adapter_Engine/Query/GetComparerForType.cs
@@ -32,6 +32,7 @@ using System.Linq;
 using System.Reflection;
 using BH.oM.Adapter;
 using BH.Engine.Diffing;
+using BH.Engine.Base.Objects;
 
 namespace BH.Engine.Adapter
 {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Engine/pull/2652
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes https://github.com/BHoM/BHoM_Adapter/issues/313

<!-- Add short description of what has been fixed -->
Added a `using` reference to support the `HashComparer` that has been moved to `BH.Engine.Base` from `BH.Engine.Diffing`.

### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/BHoM_Engine/pull/2652

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added a `using` reference to support the `HashComparer` that has been moved to `BH.Engine.Base` from `BH.Engine.Diffing`.