### PR TITLE
Fix incorrect null check on Tag prior to Push via FullCRUD

### DIFF
--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/FullCRUD.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/FullCRUD.cs
@@ -47,8 +47,8 @@ namespace BH.Adapter
             // Make sure objects are distinct 
             List<T> newObjects = objectsToPush.Distinct(Engine.Adapter.Query.GetComparerForType<T>(this)).ToList();
 
-            // Make sure objects are tagged
-            if (tag != "")
+            // Add the tag if provided
+            if (!string.IsNullOrWhiteSpace(tag))
                 newObjects.ForEach(x => x.Tags.Add(tag));
 
             //Read all the objects of that type from the external model


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #326

<!-- Add short description of what has been fixed -->
Fix an incorrect null check on tags. There was no guard against null values.

### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/BHoM_Adapter/issues/326

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->