### PR TITLE
Add caching system for CRUD methods

### DIFF
--- a/.ci/code/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
+++ b/.ci/code/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
@@ -124,12 +124,12 @@ namespace BH.Tests.Adapter
 
             List<IBHoMObject> modelObjects = Created.Where(x => x.Item1.IsAssignableFrom(type)).SelectMany(x => x.Item2).ToList();
 
-            MethodInfo method = typeof(Engine.Adapter.Query).GetMethod("GetDependencyTypes");
+            MethodInfo method = typeof(Engine.Adapter.Query).GetMethod(nameof(Engine.Adapter.Query.GetDependencyTypes));
             method = method.MakeGenericMethod(type);
 
             List<Type> dependencyTypes = method.Invoke(null, new object[] { this }) as List<Type>;
 
-            MethodInfo readCached = typeof(BHoMAdapter).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).FirstOrDefault(x => x.Name == "GetCachedOrRead");
+            MethodInfo readCached = typeof(BHoMAdapter).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).FirstOrDefault(x => x.Name == nameof(GetCachedOrRead));
 
             foreach (Type t in dependencyTypes)
             {

--- a/.ci/code/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
+++ b/.ci/code/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
@@ -129,7 +129,7 @@ namespace BH.Tests.Adapter
 
             List<Type> dependencyTypes = method.Invoke(null, new object[] { this }) as List<Type>;
 
-            MethodInfo readCached = typeof(BHoMAdapter).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).FirstOrDefault(x => x.Name == nameof(GetCachedOrRead));
+            MethodInfo readCached = typeof(BHoMAdapter).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(x => x.GetGenericArguments().Length == 1).FirstOrDefault(x => x.Name == nameof(GetCachedOrRead));
 
             foreach (Type t in dependencyTypes)
             {

--- a/.ci/code/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
+++ b/.ci/code/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
@@ -134,7 +134,7 @@ namespace BH.Tests.Adapter
             foreach (Type t in dependencyTypes)
             {
                 MethodInfo generic = readCached.MakeGenericMethod(t);
-                generic.Invoke(this, new object[] { null, null });
+                generic.Invoke(this, new object[] { null, null, actionConfig });
             }
 
             if (!CallsToReadPerType.TryGetValue(type, out int n))

--- a/Adapter_oM/Settings-Config/AdapterSettings.cs
+++ b/Adapter_oM/Settings-Config/AdapterSettings.cs
@@ -63,7 +63,7 @@ namespace BH.oM.Adapter
         public virtual bool ProcessInMemory { get; set; } = false;
         [Description("If true, Objects found to be the same according to the AdapterComparer for the provided type are checked for full equality using the HashComparer of the type (which by default checks every property except BHoM_Guid). If equal according to the HashComparer, they are not updated.\n" + 
                      "Otherwise, Objects found identical according to the AdapterComparer for the provided type are sent to the Update method.")]
-        public virtual bool OnlyUpdateChangedObjects { get; set; } = false;
+        public virtual bool OnlyUpdateChangedObjects { get; set; } = true;
 
         [Description("If true, CRUD operations will attempt read/write cache objects to speed things during a same Action.")]
         public virtual bool CacheCRUDobjects { get; set; } = true;

--- a/Adapter_oM/Settings-Config/AdapterSettings.cs
+++ b/Adapter_oM/Settings-Config/AdapterSettings.cs
@@ -65,6 +65,9 @@ namespace BH.oM.Adapter
                      "Otherwise, Objects found identical according to the AdapterComparer for the provided type are sent to the Update method.")]
         public virtual bool OnlyUpdateChangedObjects { get; set; } = false;
 
+        [Description("If true, CRUD operations will attempt read/write cache objects to speed things during a same Action.")]
+        public virtual bool CacheCRUDobjects { get; set; } = true;
+
         /****************************************/
         /****      CreateOnly settings      *****/
         /****************************************/

--- a/BHoM_Adapter/AdapterActions/Pull.cs
+++ b/BHoM_Adapter/AdapterActions/Pull.cs
@@ -72,6 +72,7 @@ namespace BH.Adapter
         [Description("Pulls objects from an external software using the basic CRUD/Read method as appropriate.")]
         public virtual IEnumerable<object> Pull(IRequest request, PullType pullType = PullType.AdapterDefault, ActionConfig actionConfig = null)
         {
+            this.ClearCache();
             // `(this as dynamic)` casts the abstract BHoMAdapter to its instance type (e.g. Speckle_Adapter), so all public ReadResults methods are captured
             if (request is IResultRequest)
                 return (this as dynamic).ReadResults(request as dynamic, actionConfig);
@@ -80,7 +81,9 @@ namespace BH.Adapter
             if (request is IRequest)
                 return (this as dynamic).Read(request as dynamic, actionConfig);
 
-            return IRead(null, null, actionConfig);
+            IEnumerable<object> read = IRead(null, null, actionConfig);
+            this.ClearCache();
+            return read;
         }
     }
 }

--- a/BHoM_Adapter/AdapterActions/Push.cs
+++ b/BHoM_Adapter/AdapterActions/Push.cs
@@ -111,7 +111,7 @@ namespace BH.Adapter
                     case PushType.FullPush:
                     case PushType.UpdateOrCreateOnly:
                     case PushType.CreateNonExisting:
-                        success &= FullCRUD(objList_specificType as dynamic, pushType, tag, actionConfig);
+                        success &= FullCRUD(objList_specificType as dynamic, group.Item2, tag, actionConfig);
                         break;
                     case PushType.CreateOnly:
                         success &= CreateOnly(objList_specificType as dynamic, tag, actionConfig);

--- a/BHoM_Adapter/AdapterActions/Push.cs
+++ b/BHoM_Adapter/AdapterActions/Push.cs
@@ -67,6 +67,7 @@ namespace BH.Adapter
         [Description("Pushes input objects using either the 'Full CRUD', 'CreateOnly' or 'UpdateOnly', depending on the PushType.")]
         public virtual List<object> Push(IEnumerable<object> objects, string tag = "", PushType pushType = PushType.AdapterDefault, ActionConfig actionConfig = null)
         {
+            this.ClearCache();
             bool success = true;
 
             // ----------------------------------------//
@@ -129,6 +130,7 @@ namespace BH.Adapter
 
             }
 
+            this.ClearCache();
             return success ? objectsToPush.Cast<object>().ToList() : new List<object>();
         }
     }

--- a/BHoM_Adapter/AdapterActions/Remove.cs
+++ b/BHoM_Adapter/AdapterActions/Remove.cs
@@ -60,6 +60,7 @@ namespace BH.Adapter
             "The base implementation just calls Delete. It can be overridden in Toolkits.")]
         public virtual int Remove(IRequest request, ActionConfig actionConfig = null)
         {
+            this.ClearCache();
             return Delete(request as dynamic, actionConfig);
         }
     }

--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/CreateOnly.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/CreateOnly.cs
@@ -58,7 +58,7 @@ namespace BH.Adapter
                 AssignNextFreeId(newObjects);
 
             // Create objects
-            if (!ICreate(newObjects, actionConfig))
+            if (!CreateAndCache(newObjects, actionConfig))
                 return false;
 
             if (callDistinct && m_AdapterSettings.UseAdapterId)

--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/CreateOnly.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/CreateOnly.cs
@@ -58,8 +58,12 @@ namespace BH.Adapter
                 AssignNextFreeId(newObjects);
 
             // Create objects
-            if ((m_AdapterSettings.CacheCRUDobjects && !CreateAndCache(newObjects, actionConfig)) 
-                || !ICreate(newObjects, actionConfig))
+            if (m_AdapterSettings.CacheCRUDobjects)
+            {
+                if (!CreateAndCache(newObjects, actionConfig))
+                    return false;
+            }
+            else if(!ICreate(newObjects, actionConfig))
                 return false;
 
             if (callDistinct && m_AdapterSettings.UseAdapterId)

--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/CreateOnly.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/CreateOnly.cs
@@ -58,7 +58,8 @@ namespace BH.Adapter
                 AssignNextFreeId(newObjects);
 
             // Create objects
-            if (!CreateAndCache(newObjects, actionConfig))
+            if ((m_AdapterSettings.CacheCRUDobjects && !CreateAndCache(newObjects, actionConfig)) 
+                || !ICreate(newObjects, actionConfig))
                 return false;
 
             if (callDistinct && m_AdapterSettings.UseAdapterId)

--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/FullCRUD.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/FullCRUD.cs
@@ -95,15 +95,19 @@ namespace BH.Adapter
             if (m_AdapterSettings.UseAdapterId)
                 AssignNextFreeId(objectsToCreate);
 
-            // Create objects
-            if (m_AdapterSettings.CacheCRUDobjects)
+            // Create objects if there are any to be created.
+            if (objectsToCreate.Any())
             {
-                if (!CreateAndCache(newObjects, actionConfig))
+                if (m_AdapterSettings.CacheCRUDobjects)
+                {
+                    if (!CreateAndCache(objectsToCreate, actionConfig))
+                        return false;
+                }
+                else if (!ICreate(objectsToCreate, actionConfig))
                     return false;
             }
-            else if (!ICreate(newObjects, actionConfig))
-                return false;
 
+            // Needs to be done even if there are no objectsToCreate as this could include updated objects
             if (m_AdapterSettings.UseAdapterId)
             {
                 // Map Ids to the original set of objects (before we extracted the distincts elements from it).

--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/FullCRUD.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/FullCRUD.cs
@@ -60,7 +60,7 @@ namespace BH.Adapter
             if (tag != "" || Engine.Adapter.Query.GetComparerForType<T>(this, actionConfig) != EqualityComparer<T>.Default)
             {
                 if (m_AdapterSettings.CacheCRUDobjects)
-                    readObjects = GetCachedOrRead<T>("", actionConfig)?.Where(x => x != null);
+                    readObjects = GetCachedOrRead<T>(null, "", actionConfig)?.Where(x => x != null);
                 else
                     readObjects = Read(typeof(T), "", actionConfig)?.Where(x => x != null && x is T).Cast<T>();
             }

--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/UpdateOnly.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/UpdateOnly.cs
@@ -49,7 +49,7 @@ namespace BH.Adapter
                 newObjects.ForEach(x => x.Tags.Add(tag));
             
             if (m_AdapterSettings.CacheCRUDobjects)
-                return UpdateCached(newObjects, actionConfig);
+                return UpdateIncludingCache(newObjects, actionConfig);
 
             return IUpdate(newObjects, actionConfig);
         }

--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/UpdateOnly.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/UpdateOnly.cs
@@ -47,8 +47,11 @@ namespace BH.Adapter
             // Make sure objects are tagged
             if (tag != "")
                 newObjects.ForEach(x => x.Tags.Add(tag));
+            
+            if (m_AdapterSettings.CacheCRUDobjects)
+                return UpdateCached(newObjects, actionConfig);
 
-            return UpdateCached(newObjects, actionConfig);
+            return IUpdate(newObjects, actionConfig);
         }
     }
 }

--- a/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/UpdateOnly.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/CRUDDispatchers/UpdateOnly.cs
@@ -48,7 +48,7 @@ namespace BH.Adapter
             if (tag != "")
                 newObjects.ForEach(x => x.Tags.Add(tag));
 
-            return IUpdate(newObjects, actionConfig);
+            return UpdateCached(newObjects, actionConfig);
         }
     }
 }

--- a/BHoM_Adapter/CRUD/Cache.cs
+++ b/BHoM_Adapter/CRUD/Cache.cs
@@ -1,0 +1,343 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.Linq;
+using BH.oM.Data.Requests;
+using BH.oM.Adapter;
+using BH.Engine.Adapter;
+using System.Xml.Linq;
+using System.Runtime.InteropServices;
+
+namespace BH.Adapter
+{
+    public abstract partial class BHoMAdapter
+    {
+        /***************************************************/
+        /**** Basic methods                             ****/
+        /***************************************************/
+
+        protected bool CreateAndCache<T>(IEnumerable<T> objects, ActionConfig actionConfig = null) where T : IBHoMObject
+        {
+            if (!ICreate(objects, actionConfig))
+                return false;
+
+            Type t = typeof(T);
+            Dictionary<object, IBHoMObject> typeCache;
+            if (!m_cache.TryGetValue(t, out typeCache))
+                typeCache = new Dictionary<object, IBHoMObject>();
+
+            if (m_AdapterSettings.UseAdapterId)
+            {
+                foreach (IBHoMObject bhObj in objects)
+                {
+                    typeCache[this.GetAdapterId(bhObj)] = bhObj;
+                }
+            }
+            else
+            {
+                // For adapters not using Ids, simply cache with integers counting up from 0.
+
+                int n = typeCache.Count;
+                foreach (IBHoMObject bhObj in objects)
+                {
+                    typeCache[n] = bhObj;
+                    n++;
+                }
+            }
+
+            m_cache[t] = typeCache;
+
+            return true;
+        }
+
+        /***************************************************/
+
+        protected virtual IEnumerable<T> ReadCashed<T>(string tag = "", ActionConfig actionConfig = null) where T : IBHoMObject
+        {
+            // Call the Basic Method Read() to get the objects based on the ids
+            IEnumerable<T> objects = ReadCashed<T>(new List<object>(), actionConfig);
+
+            // Null guard
+            objects = objects ?? new List<T>();
+
+            // Filter by tag if any 
+            if (tag == "")
+                return objects;
+            else
+                return objects.Where(x => x.Tags.Contains(tag));
+        }
+
+        /***************************************************/
+
+        protected List<T> ReadCashed<T>(IList ids, ActionConfig actionConfig = null)
+        {
+            return ReadCashedDictionary<T, object>(ids, actionConfig).Values.ToList();
+        }
+
+        /***************************************************/
+
+        protected Dictionary<TId, T> ReadCashedDictionary<T, TId>(IList ids, ActionConfig actionConfig = null)
+        {
+
+            Type t = typeof(T);
+            if (ids == null || ids.Count == 0)
+            {
+                if (m_FullyCachedTypes.Contains(typeof(T)))
+                {
+                    Dictionary<object, IBHoMObject> typeCache;
+                    if (m_cache.TryGetValue(t, out typeCache))
+                        return typeCache.ToDictionary(x => (TId)x.Key, x => (T)x.Value);
+                    else
+                        return new Dictionary<TId, T>();
+                }
+                else
+                {
+                    // Because we are in the case of no Ids specified, we want to be reading the entire model.
+                    // There may be objects that may have been read, although objects of their type may not be all read yet.
+                    // This means that, because there is no way of knowing which ids (objects) are missing to be read,
+                    // we need to re-read the entire model and cache it fully, although some reads may be redundant.
+                    IEnumerable<IBHoMObject> readObjects = IRead(t, ids, actionConfig);
+                    m_FullyCachedTypes.Add(t);
+                    Dictionary<object, IBHoMObject> typeCache;
+                    if (m_AdapterSettings.UseAdapterId)
+                    {
+                        typeCache = readObjects.ToDictionary(x => this.GetAdapterId(x), x => x);
+                        m_cache[t] = typeCache;
+                    }
+                    else
+                    {
+                        // For adapters not using Ids, simply cache with integers counting up from 0.
+                        typeCache = new Dictionary<object, IBHoMObject>();
+
+                        int n = 0;
+                        foreach (IBHoMObject bhObj in readObjects)
+                        {
+                            typeCache[n] = bhObj;
+                            n++;
+                        }
+
+                        m_cache[t] = typeCache;
+                    }
+
+                    return typeCache.ToDictionary(x => (TId)x.Key, x => (T)x.Value);
+                }
+            }
+            else
+            {
+                Dictionary<object, IBHoMObject> filteredObjects = new Dictionary<object, IBHoMObject>();
+                Dictionary<object, IBHoMObject> typeCache;
+                if (m_cache.TryGetValue(t, out typeCache))
+                {
+                    List<object> idsNotInCache = new List<object>();
+                    List<IBHoMObject> cachedObjects = new List<IBHoMObject>();
+
+                    //Loop through the ids and try to fetch from cache.
+                    foreach (object id in ids)
+                    {
+                        if (typeCache.TryGetValue(id, out IBHoMObject obj))
+                        {
+                            cachedObjects.Add(obj);
+                            filteredObjects[id] = obj;
+                        }
+                        else
+                            idsNotInCache.Add(id);
+                    }
+
+                    if (idsNotInCache.Count > 0)
+                    {
+                        //If some of the objects not found in the cache, they need to be read.
+                        //if (m_FullyCachedTypes.Contains(t))
+                        //{
+                        //    //Already read all objects, but still missing id. Return what was found and raise a warning
+                        //    Engine.Base.Compute.RecordWarning($"Unable to extract some objects of type {t.Name} with ids {string.Join(",", idsNotInCache)}.");
+                        //    return cachedObjects.OfType<T>().ToList();
+                        //}
+
+                        IEnumerable<IBHoMObject> additionalObjects = IRead(t, idsNotInCache, actionConfig);
+
+                        if (m_AdapterSettings.UseAdapterId)
+                        {
+                            foreach (IBHoMObject bhObj in additionalObjects)
+                            {
+                                object id = this.GetAdapterId(bhObj);
+                                typeCache[id] = bhObj;
+                                filteredObjects[id] = bhObj;
+                            }
+                        }
+                        else
+                        {
+                            int n = typeCache.Count;
+                            foreach (IBHoMObject bhObj in additionalObjects)
+                            {
+                                typeCache[n] = bhObj;
+                                filteredObjects[n] = bhObj;
+                                n++;
+                            }
+                        }
+                        m_cache[t] = typeCache;
+                    }
+
+                    return filteredObjects.ToDictionary(x => (TId)x.Key, x => (T)x.Value);
+                }
+                else
+                {
+                    typeCache = new Dictionary<object, IBHoMObject>();
+                    IEnumerable<IBHoMObject> readObjects = IRead(t, ids, actionConfig);
+
+                    if (m_AdapterSettings.UseAdapterId)
+                    {
+                        foreach (IBHoMObject bhObj in readObjects)
+                        {
+                            typeCache[this.GetAdapterId(bhObj)] = bhObj;
+                        }
+                    }
+                    else
+                    {
+                        int n = typeCache.Count;
+                        foreach (IBHoMObject bhObj in readObjects)
+                        {
+                            typeCache[n] = bhObj;
+                            n++;
+                        }
+                    }
+                    m_cache[t] = typeCache;
+
+                    return typeCache.ToDictionary(x => (TId)x.Key, x => (T)x.Value);
+                }
+            }
+        }
+
+        /***************************************************/
+
+        protected virtual bool UpdateCached<T>(IEnumerable<T> objects, ActionConfig actionConfig = null) where T : IBHoMObject
+        {
+            if (!IUpdate(objects, actionConfig))
+                return false;
+
+            if (!m_AdapterSettings.UseAdapterId)
+            {
+                Engine.Base.Compute.RecordWarning("Unable to update cache for adapters not using AdapterIds.");
+                return true;
+            }
+
+            Type t = typeof(T);
+            Dictionary<object, IBHoMObject> typeCache;
+            if (!m_cache.TryGetValue(t, out typeCache))
+                typeCache = new Dictionary<object, IBHoMObject>();
+
+            foreach (IBHoMObject bhObj in objects)
+            {
+                typeCache[this.GetAdapterId(bhObj)] = bhObj;
+            }
+
+            m_cache[t] = typeCache;
+
+            return true;
+        }
+
+        /***************************************************/
+
+        protected virtual int UpdateTagsCached<T>(IEnumerable<object> ids, IEnumerable<HashSet<string>> newTags, ActionConfig actionConfig = null)
+        {
+            Type t = typeof(T);
+            int updateCount = IUpdateTags(t, ids, newTags, actionConfig);
+
+            if (updateCount == 0)
+                return 0;
+
+            if (!m_AdapterSettings.UseAdapterId)
+            {
+                Engine.Base.Compute.RecordWarning("Unable to update cache for adapters not using AdapterIds.");
+                return updateCount;
+            }
+
+            Dictionary<object, IBHoMObject> typeCache;
+            if (!m_cache.TryGetValue(t, out typeCache))
+                typeCache = new Dictionary<object, IBHoMObject>();
+
+            List<object> idsList = ids.ToList();
+            List<HashSet<string>> tagsList = newTags.ToList();
+
+            if (idsList.Count != tagsList.Count)
+                return updateCount; //Not raising a warning here due to the assumption that the concrete adapter will already have done that
+
+            for (int i = 0; i < idsList.Count; i++)
+            {
+                object id = idsList[i];
+                IBHoMObject bhObj;
+                if (typeCache.TryGetValue(id, out bhObj))
+                    bhObj.Tags = tagsList[i];
+            }
+
+            m_cache[t] = typeCache;
+
+            return updateCount;
+        }
+
+        /***************************************************/
+
+        protected int DeleteFromModelAndCache<T>(IEnumerable<object> ids, ActionConfig actionConfig = null) where T : IBHoMObject
+        {
+            Type t = typeof(T);
+            int deleteCount = IDelete(t, ids, actionConfig);
+            if (deleteCount == 0)
+                return deleteCount;
+
+            if (ids == null || !ids.Any())
+            {
+                m_FullyCachedTypes.Remove(t);
+                m_cache.Remove(t);
+            }
+            else
+            {
+                Dictionary<object, IBHoMObject> typeCache;
+                if (m_cache.TryGetValue(t, out typeCache))
+                {
+                    foreach (object id in ids)
+                    {
+                        typeCache.Remove(id);
+                    }
+                }
+                m_cache[t] = typeCache;
+            }
+
+            return deleteCount;
+        }
+
+        /***************************************************/
+
+        protected void ClearCache()
+        {
+            m_cache = new Dictionary<Type, Dictionary<object, IBHoMObject>>();
+            m_FullyCachedTypes = new HashSet<Type>();
+        }
+
+        /***************************************************/
+
+        private Dictionary<Type, Dictionary<object, IBHoMObject>> m_cache = new Dictionary<Type, Dictionary<object, IBHoMObject>>();
+        private HashSet<Type> m_FullyCachedTypes = new HashSet<Type>();
+    }
+}

--- a/BHoM_Adapter/CRUD/Cache.cs
+++ b/BHoM_Adapter/CRUD/Cache.cs
@@ -31,6 +31,7 @@ using BH.Engine.Adapter;
 using System.Xml.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using System.ComponentModel;
 
 namespace BH.Adapter
 {
@@ -76,30 +77,26 @@ namespace BH.Adapter
 
         /***************************************************/
 
-        protected virtual IEnumerable<T> GetCachedOrRead<T>(string tag = "", ActionConfig actionConfig = null) where T : IBHoMObject
+        [Description("Method for getting out a list of objects from the cache or the read from the model.")]
+        protected List<T> GetCachedOrRead<T>(IList ids = null, string tag = "", ActionConfig actionConfig = null) where T : IBHoMObject
         {
-            // Call the Basic Method Read() to get the objects based on the ids
-            IEnumerable<T> objects = GetCachedOrRead<T>(new List<object>(), actionConfig);
+            // Call the method extracting from cache or reading from model as dictionary.
+            //Setting key type to object to allow for any type of key
+            List<T> objects = GetCachedOrReadAsDictionary<object, T>(ids, actionConfig).Values.ToList();
 
             // Null guard
             objects = objects ?? new List<T>();
 
             // Filter by tag if any 
-            if (tag == "")
+            if (string.IsNullOrWhiteSpace(tag))
                 return objects;
             else
-                return objects.Where(x => x.Tags.Contains(tag));
+                return objects.Where(x => x.Tags.Contains(tag)).ToList();
         }
 
         /***************************************************/
 
-        protected List<T> GetCachedOrRead<T>(IList ids, ActionConfig actionConfig = null)
-        {
-            return GetCachedOrReadAsDictionary<object, T>(ids, actionConfig).Values.ToList();
-        }
-
-        /***************************************************/
-
+        [Description("Method for getting out a Dictionary of id and object from the cache or the read from the model.")]
         protected Dictionary<TId, TObj> GetCachedOrReadAsDictionary<TId, TObj>(IList ids = null, ActionConfig actionConfig = null)
         {
 
@@ -148,6 +145,7 @@ namespace BH.Adapter
             }
             else
             {
+                //Filtered obejct collection to store the objects to be returned either from the model or from the cache
                 Dictionary<object, IBHoMObject> filteredObjects = new Dictionary<object, IBHoMObject>();
                 Dictionary<object, IBHoMObject> typeCache;
                 if (m_cache.TryGetValue(t, out typeCache))

--- a/BHoM_Adapter/CRUD/Cache.cs
+++ b/BHoM_Adapter/CRUD/Cache.cs
@@ -99,7 +99,7 @@ namespace BH.Adapter
 
         /***************************************************/
 
-        protected Dictionary<TId, T> ReadCashedDictionary<T, TId>(IList ids, ActionConfig actionConfig = null)
+        protected Dictionary<TId, T> ReadCashedDictionary<T, TId>(IList ids = null, ActionConfig actionConfig = null)
         {
 
             Type t = typeof(T);

--- a/BHoM_Adapter/CRUD/Cache.cs
+++ b/BHoM_Adapter/CRUD/Cache.cs
@@ -191,14 +191,12 @@ namespace BH.Adapter
                 if (m_cache.TryGetValue(t, out typeCache))
                 {
                     List<object> idsNotInCache = new List<object>();
-                    List<IBHoMObject> cachedObjects = new List<IBHoMObject>();
 
                     //Loop through the ids and try to fetch from cache.
                     foreach (object id in ids)
                     {
                         if (typeCache.TryGetValue(id, out IBHoMObject obj))
                         {
-                            cachedObjects.Add(obj);
                             filteredObjects[id] = obj;
                         }
                         else


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #336

<!-- Add short description of what has been fixed -->

Add caching system in the base adapter, reducing the times the same objects are read more than once from the model.

Can for some cases significantly speed up both push and pulls from the adapter, depending o the case being run.

For full effect, the concrete adapters need to be updated to make use of this new system.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->