### PR TITLE
Fix issue with deep dependency types

### DIFF
--- a/.ci/code/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
+++ b/.ci/code/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
@@ -43,6 +43,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using System.Reflection;
+using BH.Engine.Adapter;
 
 namespace BH.Tests.Adapter
 {
@@ -124,10 +125,7 @@ namespace BH.Tests.Adapter
 
             List<IBHoMObject> modelObjects = Created.Where(x => x.Item1.IsAssignableFrom(type)).SelectMany(x => x.Item2).ToList();
 
-            MethodInfo method = typeof(Engine.Adapter.Query).GetMethod(nameof(Engine.Adapter.Query.GetDependencyTypes));
-            method = method.MakeGenericMethod(type);
-
-            List<Type> dependencyTypes = method.Invoke(null, new object[] { this }) as List<Type>;
+            List<Type> dependencyTypes = this.GetDependencyTypes(type);
 
             MethodInfo readCached = typeof(BHoMAdapter).GetMethods(BindingFlags.NonPublic | BindingFlags.Instance).Where(x => x.GetGenericArguments().Length == 1).FirstOrDefault(x => x.Name == nameof(GetCachedOrRead));
 

--- a/.ci/code/BHoM_Adapter_Tests/PushTests.cs
+++ b/.ci/code/BHoM_Adapter_Tests/PushTests.cs
@@ -68,14 +68,18 @@ namespace BH.Tests.Adapter.Structure
 
             sa.Push(inputObjects);
 
-            string correctOrder = "BH.oM.Structure.Constraints.Constraint6DOF, BH.oM.Structure.MaterialFragments.IMaterialFragment, " +
-                "BH.oM.Structure.SectionProperties.ISectionProperty, BH.oM.Structure.Elements.Node, " +
-                "BH.oM.Structure.Constraints.BarRelease, BH.oM.Structure.Offsets.Offset, " +
-                "BH.oM.Structure.Elements.Bar, BH.oM.Structure.Loads.Loadcase, " +
-                "BH.oM.Structure.Loads.BarUniformlyDistributedLoad";
+            string correctOrder = "BH.oM.Structure.MaterialFragments.IMaterialFragment, " +
+                                  "BH.oM.Structure.Constraints.Constraint6DOF, " +
+                                  "BH.oM.Structure.SectionProperties.ISectionProperty, " +
+                                  "BH.oM.Structure.Elements.Node, " +
+                                  "BH.oM.Structure.Constraints.BarRelease, " +
+                                  "BH.oM.Structure.Offsets.Offset, " +
+                                  "BH.oM.Structure.Elements.Bar, " +
+                                  "BH.oM.Structure.Loads.Loadcase, " +
+                                  "BH.oM.Structure.Loads.BarUniformlyDistributedLoad";
 
             string createdOrder = string.Join(", ", sa.Created.Select(c => c.Item1.FullName));
-            Assert.IsTrue(createdOrder == correctOrder);
+            Assert.AreEqual(correctOrder, createdOrder);
         }
 
 
@@ -95,12 +99,21 @@ namespace BH.Tests.Adapter.Structure
 
             sa.Push(inputObjects);
 
-            string correctOrder = "BH.oM.Structure.Constraints.Constraint4DOF, BH.oM.Structure.MaterialFragments.IMaterialFragment, " +
-                "BH.oM.Structure.Constraints.Constraint6DOF, BH.oM.Structure.SectionProperties.ISectionProperty, " +
-                "BH.oM.Structure.Elements.Node, BH.oM.Structure.Constraints.BarRelease, BH.oM.Structure.Offsets.Offset, " +
-                "BH.oM.Structure.Elements.Bar, BH.oM.Structure.Loads.Loadcase, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, " +
-                "BH.oM.Structure.Elements.Opening, BH.oM.Structure.Elements.Edge, BH.oM.Structure.Loads.BarUniformlyDistributedLoad, " +
-                "BH.oM.Structure.Elements.FEMesh, BH.oM.Structure.Elements.Panel";
+            string correctOrder = "BH.oM.Structure.Constraints.Constraint6DOF, " +
+                                  "BH.oM.Structure.MaterialFragments.IMaterialFragment, " +
+                                  "BH.oM.Structure.Constraints.Constraint4DOF, " +
+                                  "BH.oM.Structure.Elements.Node, " +
+                                  "BH.oM.Structure.Elements.Edge, " +
+                                  "BH.oM.Structure.SectionProperties.ISectionProperty, " +
+                                  "BH.oM.Structure.Constraints.BarRelease, " +
+                                  "BH.oM.Structure.Offsets.Offset, " +
+                                  "BH.oM.Structure.SurfaceProperties.ISurfaceProperty, " +
+                                  "BH.oM.Structure.Elements.Bar, " +
+                                  "BH.oM.Structure.Loads.Loadcase, " +
+                                  "BH.oM.Structure.Elements.Opening, " +
+                                  "BH.oM.Structure.Loads.BarUniformlyDistributedLoad, " +
+                                  "BH.oM.Structure.Elements.FEMesh, " +
+                                  "BH.oM.Structure.Elements.Panel";
 
             string createdOrder = string.Join(", ", sa.Created.Select(c => c.Item1.FullName));
             Assert.AreEqual(correctOrder, createdOrder);
@@ -117,9 +130,12 @@ namespace BH.Tests.Adapter.Structure
 
             sa.Push(inputObjects, "", BH.oM.Adapter.PushType.UpdateOnly);
 
-            string correctOrderCreated = "BH.oM.Structure.MaterialFragments.IMaterialFragment, BH.oM.Structure.Constraints.Constraint6DOF, " +
-                "BH.oM.Structure.SectionProperties.ISectionProperty, BH.oM.Structure.Elements.Node, " +
-                "BH.oM.Structure.Constraints.BarRelease, BH.oM.Structure.Offsets.Offset";
+            string correctOrderCreated = "BH.oM.Structure.Constraints.Constraint6DOF, " +
+                                         "BH.oM.Structure.MaterialFragments.IMaterialFragment, " +
+                                         "BH.oM.Structure.SectionProperties.ISectionProperty, " +
+                                         "BH.oM.Structure.Elements.Node, " +
+                                         "BH.oM.Structure.Constraints.BarRelease, " +
+                                         "BH.oM.Structure.Offsets.Offset";
             string correctOrderUpdated = "BH.oM.Structure.Elements.Node, BH.oM.Structure.SectionProperties.ISectionProperty, BH.oM.Structure.Elements.Bar";
 
             string createdOrder = string.Join(", ", sa.Created.Select(c => c.Item1.FullName));

--- a/.ci/code/BHoM_Adapter_Tests/PushTests.cs
+++ b/.ci/code/BHoM_Adapter_Tests/PushTests.cs
@@ -195,6 +195,27 @@ namespace BH.Tests.Adapter.Structure
         }
 
         [Test]
+        public void DependencyOrder_CreateLoadNoObjectsWithIds()
+        {
+            List<BarUniformlyDistributedLoad> loads = Create.RandomObjects<BarUniformlyDistributedLoad>(3);
+
+            sa.Push(loads);
+
+            string correctOrder = "BH.oM.Structure.MaterialFragments.IMaterialFragment, " +
+                                  "BH.oM.Structure.Constraints.Constraint6DOF, " +
+                                  "BH.oM.Structure.SectionProperties.ISectionProperty, " +
+                                  "BH.oM.Structure.Elements.Node, " +
+                                  "BH.oM.Structure.Constraints.BarRelease, " +
+                                  "BH.oM.Structure.Offsets.Offset, " +
+                                  "BH.oM.Structure.Elements.Bar, " +
+                                  "BH.oM.Structure.Loads.Loadcase, " +
+                                  "BH.oM.Structure.Loads.BarUniformlyDistributedLoad";
+            string createdOrder = string.Join(", ", sa.Created.Select(c => c.Item1.FullName));
+
+            Assert.AreEqual(correctOrder, createdOrder);
+        }
+
+        [Test]
         public void DependencyOrder_CreateLoadAllObjectsWithIds()
         {
             List<Bar> bars = Create.RandomObjects<Bar>(10);

--- a/Adapter_Engine/Query/GetDependencyTypes.cs
+++ b/Adapter_Engine/Query/GetDependencyTypes.cs
@@ -41,7 +41,12 @@ namespace BH.Engine.Adapter
         [Description("Returns the dependency types for a certain object type.")]
         public static List<Type> GetDependencyTypes<T>(this IBHoMAdapter bhomAdapter)
         {
-            Type type = typeof(T);
+            return GetDependencyTypes(bhomAdapter, typeof(T));
+        }
+
+        [Description("Returns the dependency types for a certain object type.")]
+        public static List<Type> GetDependencyTypes(this IBHoMAdapter bhomAdapter, Type type)
+        {
             List<Type> dependencyTypes = new List<Type>();
 
             if (bhomAdapter.DependencyTypes.ContainsKey(type))


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #339

<!-- Add short description of what has been fixed -->

Fixing an issue with the dependency ordering that could occur for some cases where a deeper dependency chain required to be evaluated. Was highlighted when trying to push Bar loads by their own, leading to an error in terms of order where the Bars where pushed before for example Nodes and Sections.
Issue has now been fixed with a tweak to the sorting methodology.

Also, adding a non-generic method for extracting dependency types for a particular type.

### Test files
<!-- Link to test files to validate the proposed changes -->

Can be validated with new PushTest in verification solution.

Also, pushing a single BarLoad to Robot, while using https://github.com/BHoM/Robot_Toolkit/pull/506 should work.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->