### PR TITLE
Add pre process module for pushing loads

### DIFF
--- a/.ci/unit-tests/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
+++ b/.ci/unit-tests/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
@@ -44,6 +44,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Reflection;
 using BH.Engine.Adapter;
+using BH.Engine.Base;
 
 namespace BH.Tests.Adapter
 {
@@ -109,7 +110,11 @@ namespace BH.Tests.Adapter
 
         protected override bool ICreate<T>(IEnumerable<T> objects, ActionConfig actionConfig = null)
         {
+            ValidateCreateObjects(objects as dynamic);
+
             Created.Add(new Tuple<Type, IEnumerable<IBHoMObject>>(typeof(T), objects.OfType<IBHoMObject>()));
+
+
 
             if (!CallsToCreatePerType.TryGetValue(typeof(T), out int n))
                 CallsToCreatePerType[typeof(T)] = 1;
@@ -117,6 +122,24 @@ namespace BH.Tests.Adapter
                 CallsToCreatePerType[typeof(T)] = n + 1;
 
             return true;
+        }
+
+        private void ValidateCreateObjects(IEnumerable<object> objects)
+        { 
+            
+        }
+
+        private void ValidateCreateObjects<T>(IEnumerable<IElementLoad<T>> objects) where T : IBHoMObject
+        {
+            foreach (IElementLoad<T> load in objects)
+            {
+                foreach (IBHoMObject bhObj in load.Objects.Elements)
+                {
+                    StructuralAdapterId id = bhObj.FindFragment<StructuralAdapterId>();
+                    if (id == null)
+                        throw new Exception("Elements on loads do not contain required Ids.");
+                }
+            }
         }
 
         protected override IEnumerable<IBHoMObject> IRead(Type type, IList ids, ActionConfig actionConfig = null)

--- a/.ci/unit-tests/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
+++ b/.ci/unit-tests/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
@@ -68,7 +68,7 @@ namespace BH.Tests.Adapter
         {
             m_AdapterSettings = new AdapterSettings()
             {
-                UseAdapterId = false,
+                UseAdapterId = true,
                 OnlyUpdateChangedObjects = true,
                 CacheCRUDobjects = cacheCRUDobjects
             };
@@ -110,11 +110,10 @@ namespace BH.Tests.Adapter
 
         protected override bool ICreate<T>(IEnumerable<T> objects, ActionConfig actionConfig = null)
         {
+
             ValidateCreateObjects(objects as dynamic);
 
             Created.Add(new Tuple<Type, IEnumerable<IBHoMObject>>(typeof(T), objects.OfType<IBHoMObject>()));
-
-
 
             if (!CallsToCreatePerType.TryGetValue(typeof(T), out int n))
                 CallsToCreatePerType[typeof(T)] = 1;
@@ -189,5 +188,24 @@ namespace BH.Tests.Adapter
 
             return 0;
         }
+
+        protected override object NextFreeId(Type objectType, bool refresh = false)
+        {
+            if (refresh || !m_nextId.ContainsKey(objectType))
+            {
+                int nextId = Created.Where(x => x.Item1 == objectType).SelectMany(x => x.Item2).Count();
+                m_nextId[objectType] = nextId;
+                return nextId;
+            }
+            else
+            { 
+                int prev = m_nextId[objectType];
+                int next = prev + 1;
+                m_nextId[objectType] = next;
+                return next;
+            }
+        }
+
+        Dictionary<Type, int> m_nextId = new Dictionary<Type, int>();
     }
 }

--- a/.ci/unit-tests/BHoM_Adapter_Tests/PushTests.cs
+++ b/.ci/unit-tests/BHoM_Adapter_Tests/PushTests.cs
@@ -144,11 +144,16 @@ namespace BH.Tests.Adapter.Structure
         [Test]
         public void Dependecies_UpdateOnly()
         {
-            List<object> inputObjects = new List<object>();
+            List<IBHoMObject> inputObjects = new List<IBHoMObject>();
             inputObjects.AddRange(Create.RandomObjects<Node>(10));
             inputObjects.AddRange(Create.RandomObjects<Bar>(10));
             inputObjects.AddRange(Create.RandomObjects<SteelSection>(10));
             inputObjects.AddRange(Create.RandomObjects<AluminiumSection>(10));
+
+            for (int i = 0; i < inputObjects.Count; i++)
+            {
+                BH.Engine.Adapter.Modify.SetAdapterId(inputObjects[i], typeof(StructuralAdapterId), i);
+            }
 
             sa.Push(inputObjects, "", BH.oM.Adapter.PushType.UpdateOnly);
 
@@ -414,9 +419,14 @@ namespace BH.Tests.Adapter.Structure
         [Test]
         public void CountCRUDCallsPerType_UpdateOnly()
         {
-            List<object> inputObjects = new List<object>();
+            List<IBHoMObject> inputObjects = new List<IBHoMObject>();
             inputObjects.AddRange(Create.RandomObjects<Bar>(10));
             inputObjects.AddRange(Create.RandomObjects<SteelSection>(10));
+
+            for (int i = 0; i < inputObjects.Count; i++)
+            {
+                BH.Engine.Adapter.Modify.SetAdapterId(inputObjects[i], typeof(StructuralAdapterId), i);
+            }
 
             sa.Push(inputObjects);
             sa.Push(inputObjects, "", PushType.UpdateOnly);
@@ -438,8 +448,6 @@ namespace BH.Tests.Adapter.Structure
             inputObjects.Add(load);
 
             sa.Push(inputObjects);
-
-
         }
     }
 }

--- a/.ci/unit-tests/BHoM_Adapter_Tests/PushTests.cs
+++ b/.ci/unit-tests/BHoM_Adapter_Tests/PushTests.cs
@@ -133,9 +133,9 @@ namespace BH.Tests.Adapter.Structure
                                   "BH.oM.Structure.Elements.Bar, " +
                                   "BH.oM.Structure.Loads.Loadcase, " +
                                   "BH.oM.Structure.Elements.Opening, " +
-                                  "BH.oM.Structure.Loads.BarUniformlyDistributedLoad, " +
                                   "BH.oM.Structure.Elements.FEMesh, " +
-                                  "BH.oM.Structure.Elements.Panel";
+                                  "BH.oM.Structure.Elements.Panel, " +
+                                  "BH.oM.Structure.Loads.BarUniformlyDistributedLoad";
 
             string createdOrder = string.Join(", ", sa.Created.Select(c => c.Item1.FullName));
             Assert.AreEqual(correctOrder, createdOrder);
@@ -444,8 +444,9 @@ namespace BH.Tests.Adapter.Structure
             List<Panel> panels = Create.RandomObjects<Panel>();
             AreaUniformlyDistributedLoad load = Create.RandomObject<AreaUniformlyDistributedLoad>();
             load.Objects.Elements = panels.Cast<IAreaElement>().ToList();
-            inputObjects.AddRange(panels);
+
             inputObjects.Add(load);
+            inputObjects.AddRange(panels);
 
             sa.Push(inputObjects);
         }

--- a/.ci/unit-tests/BHoM_Adapter_Tests/PushTests.cs
+++ b/.ci/unit-tests/BHoM_Adapter_Tests/PushTests.cs
@@ -426,5 +426,20 @@ namespace BH.Tests.Adapter.Structure
             Assert.IsTrue(sa.CallsToReadPerType.Where(kv => kv.Key != typeof(Bar)).All(kv => kv.Value == 2));
             Assert.IsTrue(sa.CallsToUpdatePerType.All(kv => kv.Value == 1), "Calls to Update should be done once per each type.");
         }
+
+        [Test]
+        public void Preprocess_PanelLoads()
+        {
+            List<object> inputObjects = new List<object>();
+            List<Panel> panels = Create.RandomObjects<Panel>();
+            AreaUniformlyDistributedLoad load = Create.RandomObject<AreaUniformlyDistributedLoad>();
+            load.Objects.Elements = panels.Cast<IAreaElement>().ToList();
+            inputObjects.AddRange(panels);
+            inputObjects.Add(load);
+
+            sa.Push(inputObjects);
+
+
+        }
     }
 }

--- a/Adapter_oM/Module/IPushPreProcessModule.cs
+++ b/Adapter_oM/Module/IPushPreProcessModule.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -31,6 +32,6 @@ namespace BH.oM.Adapter.Module
     public interface IPushPreProcessModule : IAdapterModule
     {
         [Description("Method called during ProcessObjectsForPush")]
-        void PreprocessObjects(IEnumerable<object> objects);
+        IEnumerable<IBHoMObject> PreprocessObjects(IEnumerable<IBHoMObject> objects);
     }
 }

--- a/Adapter_oM/Module/IPushPreProcessModule.cs
+++ b/Adapter_oM/Module/IPushPreProcessModule.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.oM.Adapter.Module
+{
+    [Description("Module for any additional pre-processing to be done to the objects beofre being pushed. This is called after all other preprocessing, such as cloning is done.")]
+    public interface IPushPreProcessModule : IAdapterModule
+    {
+        [Description("Method called during ProcessObjectsForPush")]
+        void PreprocessObjects(IEnumerable<object> objects);
+    }
+}

--- a/Adapter_oM/Module/IPushPreProcessModule.cs
+++ b/Adapter_oM/Module/IPushPreProcessModule.cs
@@ -31,7 +31,7 @@ namespace BH.oM.Adapter.Module
     [Description("Module for any additional pre-processing to be done to the objects beofre being pushed. This is called after all other preprocessing, such as cloning is done.")]
     public interface IPushPreProcessModule : IAdapterModule
     {
-        [Description("Method called during ProcessObjectsForPush")]
+        [Description("Method called during ProcessObjectsForPush.")]
         IEnumerable<IBHoMObject> PreprocessObjects(IEnumerable<IBHoMObject> objects);
     }
 }

--- a/BHoM_Adapter/AdapterActions/_PushMethods/ProcessObjectsForPush.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/ProcessObjectsForPush.cs
@@ -97,7 +97,7 @@ namespace BH.Adapter
             //Run through any Preprocessing modules on the Adapter
             foreach (IPushPreProcessModule preprocessModule in AdapterModules.OfType<IPushPreProcessModule>())
             {
-                preprocessModule.PreprocessObjects(objectsToPush);
+                objectsToPush = preprocessModule.PreprocessObjects(objectsToPush);
             }
 
             return objectsToPush;

--- a/BHoM_Adapter/AdapterActions/_PushMethods/ProcessObjectsForPush.cs
+++ b/BHoM_Adapter/AdapterActions/_PushMethods/ProcessObjectsForPush.cs
@@ -29,6 +29,7 @@ using System.ComponentModel;
 using System.Linq;
 using BH.oM.Adapter;
 using IContainer = BH.oM.Base.IContainer;
+using BH.oM.Adapter.Module;
 
 namespace BH.Adapter
 {
@@ -92,6 +93,12 @@ namespace BH.Adapter
             // Clone the objects for immutability in the UI. CloneBeforePush should always be true, except for very specific cases.
             if (m_AdapterSettings.CloneBeforePush)
                 objectsToPush = objectsToPush.Select(x => x.DeepClone()).ToList();
+
+            //Run through any Preprocessing modules on the Adapter
+            foreach (IPushPreProcessModule preprocessModule in AdapterModules.OfType<IPushPreProcessModule>())
+            {
+                preprocessModule.PreprocessObjects(objectsToPush);
+            }
 
             return objectsToPush;
         }

--- a/Structure_AdapterModules/ModuleLoader.cs
+++ b/Structure_AdapterModules/ModuleLoader.cs
@@ -47,6 +47,7 @@ namespace BH.Adapter.Modules.Structure
             adapter.AdapterModules.Add(new GetGravityLoadElementsWithoutID<Bar>(adapter));
             adapter.AdapterModules.Add(new GetGravityLoadElementsWithoutID<Panel>(adapter));
             adapter.AdapterModules.Add(new GetGravityLoadElementsWithoutID<FEMesh>(adapter));
+            adapter.AdapterModules.Add(new ReplaceObjectsInLoadsModule());
         }
     }
 }

--- a/Structure_AdapterModules/PreProcessLoads.cs
+++ b/Structure_AdapterModules/PreProcessLoads.cs
@@ -1,0 +1,69 @@
+﻿using BH.oM.Adapter.Module;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using BH.oM.Structure.Loads;
+using BH.oM.Base;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.ComponentModel;
+
+namespace BH.Adapter.Modules.Structure
+{
+    [Description("Module for replacing the objects in the loads with objects with the same BHoM_Guid being pushed at the same time.\n" +
+                 "No action is taken if loads are pushed in isolation, without the elements pushed at the same time as individual instances.")]
+    public class ReplaceObjectsInLoadsModule : IPushPreProcessModule
+    {
+        public void PreprocessObjects(IEnumerable<object> objects)
+        {
+            return;
+            IEnumerable<IBHoMObject> bhObjs = objects.OfType<IBHoMObject>();
+
+            List<ILoad> loads = new List<ILoad>();
+            Dictionary<Guid, IBHoMObject> nonLoads = new Dictionary<Guid, IBHoMObject>();
+
+            //Split load obejcts from non-load objects
+            foreach (IBHoMObject obj in bhObjs)
+            {
+                if (obj is ILoad load)
+                    loads.Add(load);
+                else if(!(obj is ICase))
+                    nonLoads[obj.BHoM_Guid] = obj;
+            }
+
+            //If no non-load obejcts are being pushed, can simply return, as nothing can be replaced
+            if (nonLoads.Count == 0)
+                return;
+
+            foreach (ILoad load in loads)
+            {
+                //Load through all loads, and try to update the objects
+                ReplaceObjects(load as dynamic, nonLoads);
+            }
+        }
+
+
+        private void ReplaceObjects<T>(IElementLoad<T> load, Dictionary<Guid, IBHoMObject> objects) where T : IBHoMObject
+        {
+            //Run through all elements stored on the load
+            for (int i = 0; i < load.Objects.Elements.Count; i++)
+            {
+                //Try to find an item with the same guid in the non-load objects
+                if (objects.TryGetValue(load.Objects.Elements[i].BHoM_Guid, out IBHoMObject replacement))
+                {
+                    //Ensure the found object is of the correct type
+                    if (replacement is T tObject)
+                    {
+                        //replace with the other object
+                        load.Objects.Elements[i] = tObject;
+                    }
+                }
+            }
+        }
+
+        private void ReplaceObjects(ILoad load, Dictionary<Guid, IBHoMObject> objects)
+        {
+            //Do nothing for non-element loads
+        }
+    }
+}

--- a/Structure_AdapterModules/PreProcessLoads.cs
+++ b/Structure_AdapterModules/PreProcessLoads.cs
@@ -16,7 +16,6 @@ namespace BH.Adapter.Modules.Structure
     {
         public void PreprocessObjects(IEnumerable<object> objects)
         {
-            return;
             IEnumerable<IBHoMObject> bhObjs = objects.OfType<IBHoMObject>();
 
             List<ILoad> loads = new List<ILoad>();

--- a/Structure_AdapterModules/ReplaceObjectsInLoadsModule.cs
+++ b/Structure_AdapterModules/ReplaceObjectsInLoadsModule.cs
@@ -14,31 +14,34 @@ namespace BH.Adapter.Modules.Structure
                  "No action is taken if loads are pushed in isolation, without the elements pushed at the same time as individual instances.")]
     public class ReplaceObjectsInLoadsModule : IPushPreProcessModule
     {
-        public void PreprocessObjects(IEnumerable<object> objects)
+        public IEnumerable<IBHoMObject> PreprocessObjects(IEnumerable<IBHoMObject> objects)
         {
-            IEnumerable<IBHoMObject> bhObjs = objects.OfType<IBHoMObject>();
-
             List<ILoad> loads = new List<ILoad>();
             Dictionary<Guid, IBHoMObject> nonLoads = new Dictionary<Guid, IBHoMObject>();
 
             //Split load obejcts from non-load objects
-            foreach (IBHoMObject obj in bhObjs)
+            foreach (IBHoMObject obj in objects)
             {
                 if (obj is ILoad load)
                     loads.Add(load);
-                else if(!(obj is ICase))
+                else
                     nonLoads[obj.BHoM_Guid] = obj;
             }
 
             //If no non-load obejcts are being pushed, can simply return, as nothing can be replaced
             if (nonLoads.Count == 0)
-                return;
+                return objects;
 
             foreach (ILoad load in loads)
             {
                 //Load through all loads, and try to update the objects
                 ReplaceObjects(load as dynamic, nonLoads);
             }
+
+            //Returns the objects in order of first non-loads followed by loads
+            //This ensures that the objects are pushed before loads
+            //For many cases this will be handled by dependency types, but for cases where this is yet to be implemented, this solution helps fix the order
+            return nonLoads.Values.Concat(loads);
         }
 
 

--- a/Structure_AdapterModules/ReplaceObjectsInLoadsModule.cs
+++ b/Structure_AdapterModules/ReplaceObjectsInLoadsModule.cs
@@ -1,4 +1,26 @@
-﻿using BH.oM.Adapter.Module;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapter.Module;
 using System;
 using System.Collections.Generic;
 using System.Text;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #347 
Closes #348 

<!-- Add short description of what has been fixed -->

- Adding `IPushPreProcessModule` to enable additional pre-processing to be done lastly in the ProcessObjectsBeforePush method
- Add Module of this new type for handling applying objects to loads being pushed at the same time, based on Guid mapping. This can for example help with Bars pushed at the same time as a Bar load, where this can replace the bars on the load with the same bar being pushed independently, and will for this case ensure the same bars are being reffered to in both cases.

### Test files
<!-- Link to test files to validate the proposed changes -->

Test case added in the test project.

Test case for Robot here:

[Uploading Beam_Cantilever_convertedFromKarambaInternalised.zip…]()

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->