### PR TITLE
Fix get dependency modules depending on order in constructor

### DIFF
--- a/.ci/unit-tests/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
+++ b/.ci/unit-tests/BHoM_Adapter_Tests/Objects/StructuralAdapter.cs
@@ -104,8 +104,9 @@ namespace BH.Tests.Adapter
                 {typeof(BarRelease), new NameOrDescriptionComparer() }
             };
 
-            AdapterIdFragmentType = typeof(StructuralAdapterId);
+
             BH.Adapter.Modules.Structure.ModuleLoader.LoadModules(this);
+            AdapterIdFragmentType = typeof(StructuralAdapterId);
         }
 
         protected override bool ICreate<T>(IEnumerable<T> objects, ActionConfig actionConfig = null)

--- a/Structure_AdapterModules/GetGravityLoadElementsWithoutID.cs
+++ b/Structure_AdapterModules/GetGravityLoadElementsWithoutID.cs
@@ -45,27 +45,36 @@ namespace BH.Adapter.Modules
 
         public IEnumerable<T> GetDependencies(IEnumerable<GravityLoad> objects)
         {
-            List<T> noIdLoadObjects = new List<T>();
-            foreach (GravityLoad load in objects)
-            {
-                if(load?.Objects?.Elements != null)
-                    noIdLoadObjects.AddRange(load.Objects.Elements.OfType<T>().Where(x => x != null && !x.Fragments.Contains(m_adapterIdType)));
-            }
-            return noIdLoadObjects;
-        }
 
+            if (m_adapter?.AdapterIdFragmentType == null)
+            {
+                string adapterType = m_adapter == null ? "Adapter" : m_adapter.GetType().Name;
+                BH.Engine.Base.Compute.RecordWarning($"{adapterType} does not have a set {nameof(m_adapter.AdapterIdFragmentType)}. Unable to filter load objects by set ID. All objects on the load will be treated as a dependency.");
+                return objects.Select(x => x?.Objects?.Elements).Where(x => x != null).SelectMany(x => x).Where(x => x != null).OfType<T>().ToList();
+            }
+            else
+            {
+                List<T> noIdLoadObjects = new List<T>();
+                foreach (GravityLoad load in objects)
+                {
+                    if (load?.Objects?.Elements != null)
+                        noIdLoadObjects.AddRange(load.Objects.Elements.OfType<T>().Where(x => x != null && !x.Fragments.Contains(m_adapter.AdapterIdFragmentType)));
+                }
+                return noIdLoadObjects;
+            }
+        }
         /***************************************************/
         /**** Constructors                              ****/
         /***************************************************/
 
         public GetGravityLoadElementsWithoutID(IBHoMAdapter adapter)
         {
-            m_adapterIdType = adapter.AdapterIdFragmentType;
+            m_adapter = adapter;
         }
 
         /***************************************************/
 
-        private Type m_adapterIdType;
+        private IBHoMAdapter m_adapter;
 
         /***************************************************/
     }

--- a/Structure_AdapterModules/GetLoadElementsWithoutID.cs
+++ b/Structure_AdapterModules/GetLoadElementsWithoutID.cs
@@ -45,13 +45,23 @@ namespace BH.Adapter.Modules
 
         public IEnumerable<T> GetDependencies(IEnumerable<IElementLoad<T>> objects)
         {
-            List<T> noIdLoadObjects = new List<T>();
-            foreach (IElementLoad<T> load in objects)
+            if (m_adapter?.AdapterIdFragmentType == null)
             {
-                if(load?.Objects?.Elements != null)
-                    noIdLoadObjects.AddRange(load.Objects.Elements.Where(x => x != null && !x.Fragments.Contains(m_adapterIdType)));
+                string adapterType = m_adapter == null ? "Adapter" : m_adapter.GetType().Name;
+                BH.Engine.Base.Compute.RecordWarning($"{adapterType} does not have a set {nameof(m_adapter.AdapterIdFragmentType)}. Unable to filter load objects by set ID. All objects on the load will be treated as a dependency.");
+                return objects.Select(x => x?.Objects?.Elements).Where(x => x != null).SelectMany(x => x).Where(x => x != null).ToList();
             }
-            return noIdLoadObjects;
+            else
+            {
+                List<T> noIdLoadObjects = new List<T>();
+                foreach (IElementLoad<T> load in objects)
+                {
+                    if (load?.Objects?.Elements != null)
+                        noIdLoadObjects.AddRange(load.Objects.Elements.Where(x => x != null && !x.Fragments.Contains(m_adapter.AdapterIdFragmentType)));
+                }
+                return noIdLoadObjects;
+            }
+
         }
 
         /***************************************************/
@@ -60,12 +70,12 @@ namespace BH.Adapter.Modules
 
         public GetLoadElementsWithoutID(IBHoMAdapter adapter)
         {
-            m_adapterIdType = adapter.AdapterIdFragmentType;
+            m_adapter = adapter;
         }
 
         /***************************************************/
 
-        private Type m_adapterIdType;
+        private IBHoMAdapter m_adapter;
 
         /***************************************************/
     }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #357

<!-- Add short description of what has been fixed -->

Fixes problem with call order of ModuleLoader and setting AdapterIdType. See issue for more details

### Test files
<!-- Link to test files to validate the proposed changes -->

All unittests should pass after change or calls in the constructor for SA

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->