### PR TITLE
Adapter_oM: Remove IObject implementation on `ModuleSet` class

### DIFF
--- a/Adapter_oM/Module/ModuleSet.cs
+++ b/Adapter_oM/Module/ModuleSet.cs
@@ -30,7 +30,7 @@ using BH.oM.Base;
 
 namespace BH.oM.Adapter
 {
-    public class ModuleSet : HashSet<IAdapterModule>, IObject
+    public class ModuleSet : HashSet<IAdapterModule>
     {
         public ModuleSet() :
             base(new TypeComparer())


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #367

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Existing unit tests, existing adapter scripts.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Removed the `IObject` implementation on `ModuleSet` class, because the adapter modules are not intended to be serializable or used from a front-end.

### Additional comments
<!-- As required -->