### PR TITLE
Fix ETABS Levels Pushing

### DIFF
--- a/Adapter_Engine/Adapter_Engine.csproj
+++ b/Adapter_Engine/Adapter_Engine.csproj
@@ -78,6 +78,9 @@
       <Private>false</Private>
       <SpecificVersion>false</SpecificVersion>
     </Reference>
+    <Reference Include="Spatial_oM">
+      <HintPath>..\..\BHoM\Spatial_oM\obj\Debug\netstandard2.0\Spatial_oM.dll</HintPath>
+    </Reference>
     <Reference Include="Structure_oM">
       <HintPath>$(ProgramData)\BHoM\Assemblies\Structure_oM.dll</HintPath>
       <Private>false</Private>

--- a/BHoM_Adapter/BHoM_Adapter.csproj
+++ b/BHoM_Adapter/BHoM_Adapter.csproj
@@ -79,6 +79,9 @@
 	  <Private>false</Private>
 	  <SpecificVersion>false</SpecificVersion>
     </Reference>
+    <Reference Include="Spatial_oM">
+      <HintPath>..\..\BHoM\Spatial_oM\obj\Debug\netstandard2.0\Spatial_oM.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### NOTE: Depends on 
[https://github.com/BHoM/ETABS_Toolkit/compare/ETABS_Toolkit-%23435-FixLevelsPushing?expand=1](url)
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #435 from the ETABS Toolkit

When using ETABS, it's necessary to push levels before any other objects to avoid errors.
Separating the levels from all the other objects and making sure that they are always pushed first into the new blank ETABS model, it's possible to resolve this issue.


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
Separated Levels from other objects making sure they are pushed first.


### Additional comments
<!-- As required -->