### PR TITLE
Add GetActiveObject method to allow its use in .NET Core environments

### DIFF
--- a/Adapter_Engine/Query/GetActiveObject.cs
+++ b/Adapter_Engine/Query/GetActiveObject.cs
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Adapter;
+using BH.oM.Base;
+using BH.Engine.Base;
+using BH.oM.Base.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Collections;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Security;
+
+namespace BH.Engine.Adapter
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+        [System.Security.SecurityCritical]  // auto-generated_required
+        [Description("Method to allow the System.InteropServices.Marshal.GetActiveObject() to be run within environments \n" +
+            "that use .NET Core such as Rhino 8.")]
+        [Input("progID", "The program id to retrieve the active object of.")]
+        public static Object GetActiveObject(String progID)
+        {
+            Object obj = null;
+            Guid clsid;
+
+            // Call CLSIDFromProgIDEx first then fall back on CLSIDFromProgID if
+            // CLSIDFromProgIDEx doesn't exist.
+            try
+            {
+                CLSIDFromProgIDEx(progID, out clsid);
+            }
+            catch (Exception)
+            {
+                CLSIDFromProgID(progID, out clsid);
+            }
+
+            GetActiveObject(ref clsid, IntPtr.Zero, out obj);
+            return obj;
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        //[DllImport(Microsoft.Win32.Win32Native.OLE32, PreserveSig = false)]
+        [DllImport(OLE32, PreserveSig = false)]
+        [ResourceExposure(ResourceScope.None)]
+        [SuppressUnmanagedCodeSecurity]
+        [System.Security.SecurityCritical]  // auto-generated
+        private static extern void CLSIDFromProgIDEx([MarshalAs(UnmanagedType.LPWStr)] String progId, out Guid clsid);
+
+        /***************************************************/
+
+        //[DllImport(Microsoft.Win32.Win32Native.OLE32, PreserveSig = false)]
+        [DllImport(OLE32, PreserveSig = false)]
+        [ResourceExposure(ResourceScope.None)]
+        [SuppressUnmanagedCodeSecurity]
+        [System.Security.SecurityCritical]  // auto-generated
+        private static extern void CLSIDFromProgID([MarshalAs(UnmanagedType.LPWStr)] String progId, out Guid clsid);
+
+        /***************************************************/
+
+        //[DllImport(Microsoft.Win32.Win32Native.OLEAUT32, PreserveSig = false)]
+        [DllImport(OLEAUT32, PreserveSig = false)]
+        [ResourceExposure(ResourceScope.None)]
+        [SuppressUnmanagedCodeSecurity]
+        [System.Security.SecurityCritical]  // auto-generated
+        private static extern void GetActiveObject(ref Guid rclsid, IntPtr reserved, [MarshalAs(UnmanagedType.Interface)] out Object ppunk);
+
+        /***************************************************/
+        /**** Internal constants                        ****/
+        /***************************************************/
+
+        internal const String OLEAUT32 = "oleaut32.dll";
+        internal const String OLE32 = "ole32.dll";
+
+        /***************************************************/
+
+    }
+}
+
+
+
+

--- a/Adapter_Engine/Query/GetActiveObject.cs
+++ b/Adapter_Engine/Query/GetActiveObject.cs
@@ -42,8 +42,8 @@ namespace BH.Engine.Adapter
         /**** Public Methods                            ****/
         /***************************************************/
         [System.Security.SecurityCritical]  // auto-generated_required
-        [Description("Method to allow the System.InteropServices.Marshal.GetActiveObject() to be run within environments \n" +
-            "that use .NET Core such as Rhino 8.")]
+        [Description("Returns the active objects of the program id specified. This allows the Marshal.GetActiveObject() \n" +
+            "to be run within environments that use .NET Core such as Rhino 8.")]
         [Input("progID", "The program id to retrieve the active object of.")]
         public static Object GetActiveObject(String progID)
         {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #397 

<!-- Add short description of what has been fixed -->

### Test files
<!-- Link to test files to validate the proposed changes -->
[Installer](https://burohappold.sharepoint.com/:f:/s/BHoM/EngdHnX9w_5Jr0c2sk7UwmkBUM7VocNTlrLZjH2NZEYk4A?e=C3wYUz)

As a minimum test for each adapter:
1. Run the adapter in Rhino 8;
2. Push a `Bar`;
3. Run an `Execute` method;
4. Pull a result.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added `GetActiveObject` method that calls directly from the DLLs to allow adapters built using .NET Framework to function in .NET Core environments such as Rhino 8.

### Additional comments
<!-- As required -->