### PR TITLE
Add import to the execute actions

### DIFF
--- a/Adapter_oM/ExecuteCommands/Import.cs
+++ b/Adapter_oM/ExecuteCommands/Import.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.oM.Adapter.Commands
+{
+    [Description("Used to instruct the external software to import a file.")]
+    public class Import : IExecuteCommand
+    {
+        public virtual string FileName { get; set; }
+    }
+}

--- a/Adapter_oM/ExecuteCommands/Import.cs
+++ b/Adapter_oM/ExecuteCommands/Import.cs
@@ -30,7 +30,7 @@ using System.Threading.Tasks;
 namespace BH.oM.Adapter.Commands
 {
     [Description("Used to instruct the external software to import a file.")]
-    public class Import : IExecuteCommand
+    public class ImportFile : IExecuteCommand
     {
         public virtual string FilePath { get; set; }
     }

--- a/Adapter_oM/ExecuteCommands/Import.cs
+++ b/Adapter_oM/ExecuteCommands/Import.cs
@@ -32,6 +32,6 @@ namespace BH.oM.Adapter.Commands
     [Description("Used to instruct the external software to import a file.")]
     public class Import : IExecuteCommand
     {
-        public virtual string FileName { get; set; }
+        public virtual string FilePath { get; set; }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #400 

Sets up import as a global execute action.


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added `ImportFile` execute action for adapters to import supported file types.

### Additional comments
<!-- As required -->